### PR TITLE
Feat: 서치뷰 커스텀 컬러, 태그 적용

### DIFF
--- a/Ting/Search/SearchSelectModal.swift
+++ b/Ting/Search/SearchSelectModal.swift
@@ -1,0 +1,140 @@
+//
+//  SearchSelectModal.swift
+//  Ting
+//
+//  Created by t2023-m0033 on 1/26/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+/// 검색 카테고리 설정 모달
+final class SearchSelectModal: UIView {
+    
+    // 카테고리 목록
+    let categories: [(String, [String])] = [
+        ("게시글 구분", ["팀원모집", "팀 구함"]),
+        ("직무", ["개발", "기획", "디자인", "마케터", "데이터"]),
+        ("시급성", ["급함", "보통", "여유로움"]),
+        ("아이디어 상황", ["구체적임", "모호함", "없음"]),
+        ("경험", ["처음 입문", "재직중", "휴직중", "취준중"])
+    ]
+    
+    // 카테고리별 StackView 담을 스크롤 뷰
+    private let scrollView = UIScrollView().then {
+        $0.showsVerticalScrollIndicator = true
+    }
+    
+    private let contentView = UIView()
+    
+    // 모든 카테고리 버튼을 담을 배열
+    var categoryButtons: [UIButton] = []
+    
+    // 필터 적용 버튼
+    let applyFilterButton = UIButton(type: .system).then {
+        $0.setTitle("필터 적용하기", for: .normal)
+        $0.tintColor = .white
+        $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .regular)
+        $0.backgroundColor = .primary
+        $0.layer.cornerRadius = 10
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - UI 설정
+    private func setupUI() {
+        backgroundColor = .background
+        
+        addSubview(scrollView)
+        addSubview(applyFilterButton)
+        
+        scrollView.addSubview(contentView)
+        
+        scrollView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalTo(applyFilterButton.snp.top).offset(-20)
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalTo(scrollView.snp.width)
+        }
+        
+        applyFilterButton.snp.makeConstraints {
+            $0.bottom.equalTo(safeAreaLayoutGuide).inset(20)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(280)
+            $0.height.equalTo(50)
+        }
+        
+        setupCategoryButtons()
+    }
+    
+    // MARK: - 카테고리 버튼 동적 생성
+    private func setupCategoryButtons() {
+        var previousView: UIView? = nil
+        
+        for (category, items) in categories {
+            let categoryLabel = UILabel().then {
+                $0.text = category
+                $0.font = UIFont.boldSystemFont(ofSize: 16)
+                $0.textColor = .deepCocoa // 카테고리 주제 글자 색상
+            }
+            
+            let buttonStackView = UIStackView().then {
+                $0.axis = .horizontal
+                $0.spacing = 8
+                $0.distribution = .fillProportionally
+            }
+            
+            for str in items {
+                let button = createCategoryButtons(title: str)
+                categoryButtons.append(button)
+                buttonStackView.addArrangedSubview(button)
+            }
+            
+            contentView.addSubview(categoryLabel)
+            contentView.addSubview(buttonStackView)
+            
+            categoryLabel.snp.makeConstraints {
+                $0.top.equalTo(previousView?.snp.bottom ?? contentView.snp.top).offset(20)
+                $0.leading.equalToSuperview()
+            }
+            
+            buttonStackView.snp.makeConstraints {
+                $0.top.equalTo(categoryLabel.snp.bottom).offset(10)
+                $0.leading.equalToSuperview()
+            }
+            
+            previousView = buttonStackView
+        }
+        
+        // 마지막 요소의 하단을 contentView에 맞춤
+        previousView?.snp.makeConstraints {
+            $0.bottom.equalToSuperview().offset(-20)
+        }
+    }
+    
+    // MARK: - 카테고리 버튼 생성
+    private func createCategoryButtons(title: String) -> UIButton {
+        let button = CustomTag(
+            title: title,
+            /// TODO - 글씨, 테두리 색상 고민
+            titleColor: .primary,
+            strokeColor: .secondary,
+            backgroundColor: .white,
+            isButton: true
+        )
+        return button
+    }
+}
+

--- a/Ting/Search/SearchSelectModalVC.swift
+++ b/Ting/Search/SearchSelectModalVC.swift
@@ -1,0 +1,50 @@
+//
+//  SearchSelectModalVC.swift
+//  Ting
+//
+//  Created by t2023-m0033 on 1/26/25.
+//
+
+import UIKit
+
+final class SearchSelectModalVC: UIViewController {
+    
+    // 카테고리 선택 모달
+    private let modalView = SearchSelectModal()
+    
+    override func loadView() {
+        view = modalView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupActions()
+    }
+    
+    private func setupActions() {
+        // 카테고리 버튼 액션 설정
+        modalView.categoryButtons.forEach { button in
+            button.addTarget(self, action: #selector(categoryButtonTapped), for: .touchUpInside)
+        }
+        
+        // 필터 적용 버튼 액션
+        modalView.applyFilterButton.addTarget(self, action: #selector(applyFilterTapped), for: .touchUpInside)
+    }
+    
+    // 카테고리버튼 배경색 & 글자색 변경
+    @objc private func categoryButtonTapped(_ sender: CustomTag) {
+        sender.isSelected.toggle()
+        /// TODO - 선택된 카테고리 데이터 담기
+        ///
+        print(sender.titleLabel?.text ?? "")
+    }
+    
+    // 적용버튼
+    @objc private func applyFilterTapped() {
+        print("필터 적용 버튼 클릭됨")
+        /// TODO - 선택된 카테고리 데이터 넘기기 (searchView로)
+        
+        dismiss(animated: true)
+    }
+    
+}

--- a/Ting/Search/SearchV.swift
+++ b/Ting/Search/SearchV.swift
@@ -39,7 +39,7 @@ class SearchView: UIView {
     let applyFilterButton = UIButton().then {
         $0.setTitle("필터 적용하기", for: .normal)
         $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = UIColor(hex: "#C2410C")
+        $0.backgroundColor = .primary
         $0.layer.cornerRadius = 10
     }
     
@@ -54,7 +54,7 @@ class SearchView: UIView {
     
     // MARK: - UI 설정
     private func setupUI() {
-        backgroundColor = UIColor(hex: "#FFF7ED")
+        backgroundColor = .background
         
         addSubview(searchBar)
         addSubview(scrollView)
@@ -95,7 +95,7 @@ class SearchView: UIView {
             let categoryLabel = UILabel().then {
                 $0.text = category
                 $0.font = UIFont.boldSystemFont(ofSize: 16)
-                $0.textColor = UIColor(hex: "#C2410C") // 카테고리 주제 글자 색상
+                $0.textColor = .primary // 카테고리 주제 글자 색상
             }
             
             let buttonStackView = UIStackView().then {
@@ -136,12 +136,12 @@ class SearchView: UIView {
     private func createFilterButton(title: String) -> UIButton {
         let button = UIButton().then {
             $0.setTitle(title, for: .normal)
-            $0.setTitleColor(UIColor(hex: "#9A3412"), for: .normal) // ✅ 기본 글자 색상 (갈색)
-            $0.layer.borderColor = UIColor(hex: "#FB923C").cgColor // ✅ 테두리 색상
+            $0.setTitleColor(.accent, for: .normal) // ✅ 기본 글자 색상 (갈색)
+            $0.layer.borderColor = UIColor.secondary.cgColor // ✅ 테두리 색상
             $0.layer.borderWidth = 1
             $0.layer.cornerRadius = 15
             $0.titleLabel?.font = UIFont.systemFont(ofSize: 14)
-            $0.backgroundColor = UIColor(hex: "#FFFFFF") // ✅ 기본 배경색 (흰색)
+            $0.backgroundColor = .white // ✅ 기본 배경색 (흰색)
             
             // iOS 15 이상에서는 UIButtonConfiguration 사용
             if #available(iOS 15.0, *) {
@@ -162,19 +162,14 @@ class SearchView: UIView {
     
     // MARK: - 버튼 클릭 이벤트 (배경색 & 글자색 변경)
     @objc private func filterButtonTapped(_ sender: UIButton) {
-        let selectedBackgroundColor = UIColor(hex: "#C2410C") // ✅ 선택된 배경색 (주황)
-        let defaultBackgroundColor = UIColor(hex: "#FFFFFF") // ✅ 기본 배경색 (흰색)
-        
-        let selectedTextColor = UIColor.white // ✅ 선택 시 글자 색상 (흰색)
-        let defaultTextColor = UIColor(hex: "#9A3412") // ✅ 기본 글자 색상 (갈색)
         
         // 현재 상태에 따라 배경색 & 글자색 변경
-        if sender.backgroundColor == defaultBackgroundColor {
-            sender.backgroundColor = selectedBackgroundColor
-            sender.setTitleColor(selectedTextColor, for: .normal) // ✅ 글자색 변경 (흰색)
+        if sender.backgroundColor == .white {
+            sender.backgroundColor = .primary
+            sender.setTitleColor(.white, for: .normal) // ✅ 글자색 변경 (흰색)
         } else {
-            sender.backgroundColor = defaultBackgroundColor
-            sender.setTitleColor(defaultTextColor, for: .normal) // ✅ 글자색 변경 (갈색)
+            sender.backgroundColor = .white
+            sender.setTitleColor(.accent, for: .normal) // ✅ 글자색 변경 (갈색)
         }
     }
 }

--- a/Ting/Search/SearchV.swift
+++ b/Ting/Search/SearchV.swift
@@ -10,7 +10,7 @@ import SnapKit
 import Then
 
 /// 검색 화면 UI를 담당하는 뷰
-class SearchView: UIView {
+final class SearchView: UIView {
     
     // 🔍 검색창
     let searchBar = UISearchBar().then {
@@ -29,11 +29,14 @@ class SearchView: UIView {
     ]
     
     // 카테고리별 StackView 담을 스크롤 뷰
-    let scrollView = UIScrollView().then {
+    private let scrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
     }
     
-    let contentView = UIView()
+    private let contentView = UIView()
+    
+    // 모든 카테고리 버튼을 담을 배열
+    var categoryButtons: [UIButton] = []
     
     // 필터 적용 버튼
     let applyFilterButton = UIButton().then {
@@ -95,18 +98,18 @@ class SearchView: UIView {
             let categoryLabel = UILabel().then {
                 $0.text = category
                 $0.font = UIFont.boldSystemFont(ofSize: 16)
-                $0.textColor = .primary // 카테고리 주제 글자 색상
+                $0.textColor = .deepCocoa // 카테고리 주제 글자 색상
             }
             
             let buttonStackView = UIStackView().then {
                 $0.axis = .horizontal
                 $0.spacing = 8
-                $0.alignment = .leading
                 $0.distribution = .fillProportionally
             }
             
             for item in items {
                 let button = createFilterButton(title: item)
+                categoryButtons.append(button)
                 buttonStackView.addArrangedSubview(button)
             }
             
@@ -120,7 +123,7 @@ class SearchView: UIView {
             
             buttonStackView.snp.makeConstraints {
                 $0.top.equalTo(categoryLabel.snp.bottom).offset(10)
-                $0.leading.trailing.equalToSuperview()
+                $0.leading.equalToSuperview()
             }
             
             previousView = buttonStackView
@@ -132,44 +135,16 @@ class SearchView: UIView {
         }
     }
     
-    // MARK: - 필터 버튼 생성 (iOS 15 대응)
+    // MARK: - 필터 버튼 생성
     private func createFilterButton(title: String) -> UIButton {
-        let button = UIButton().then {
-            $0.setTitle(title, for: .normal)
-            $0.setTitleColor(.accent, for: .normal) // ✅ 기본 글자 색상 (갈색)
-            $0.layer.borderColor = UIColor.secondary.cgColor // ✅ 테두리 색상
-            $0.layer.borderWidth = 1
-            $0.layer.cornerRadius = 15
-            $0.titleLabel?.font = UIFont.systemFont(ofSize: 14)
-            $0.backgroundColor = .white // ✅ 기본 배경색 (흰색)
-            
-            // iOS 15 이상에서는 UIButtonConfiguration 사용
-            if #available(iOS 15.0, *) {
-                var config = UIButton.Configuration.plain()
-                config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12)
-                $0.configuration = config
-            } else {
-                // iOS 14 이하에서는 기존 contentEdgeInsets 사용
-                $0.contentEdgeInsets = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
-            }
-            
-            // ✅ 버튼 클릭 시 배경색 & 글자색 변경
-            $0.addTarget(self, action: #selector(filterButtonTapped(_:)), for: .touchUpInside)
-        }
-        
+        let button = CustomTag(
+            title: title,
+            /// TODO - 글씨, 테두리 색상 고민
+            titleColor: .brownText,
+            strokeColor: .secondary,
+            backgroundColor: .white,
+            isButton: true
+        )
         return button
-    }
-    
-    // MARK: - 버튼 클릭 이벤트 (배경색 & 글자색 변경)
-    @objc private func filterButtonTapped(_ sender: UIButton) {
-        
-        // 현재 상태에 따라 배경색 & 글자색 변경
-        if sender.backgroundColor == .white {
-            sender.backgroundColor = .primary
-            sender.setTitleColor(.white, for: .normal) // ✅ 글자색 변경 (흰색)
-        } else {
-            sender.backgroundColor = .white
-            sender.setTitleColor(.accent, for: .normal) // ✅ 글자색 변경 (갈색)
-        }
     }
 }

--- a/Ting/Search/SearchVC.swift
+++ b/Ting/Search/SearchVC.swift
@@ -25,11 +25,24 @@ class SearchVC: UIViewController {
     
     // MARK: - 버튼 액션 설정
     private func setupActions() {
+        
+        // 모든 카테고리 버튼에 액션 추가
+        searchView.categoryButtons.forEach { button in
+            button.addTarget(self, action: #selector(categoryButtonTapped), for: .touchUpInside)
+        }
+        
         searchView.applyFilterButton.addTarget(self, action: #selector(applyFilterTapped), for: .touchUpInside)
     }
     
+    // MARK: - 버튼 클릭 이벤트
+    // 카테고리버튼 배경색 & 글자색 변경
+    @objc private func categoryButtonTapped(_ sender: UIButton) {
+        sender.isSelected.toggle()
+    }
+    
+    // 적용버튼
     @objc private func applyFilterTapped() {
         print("필터 적용 버튼 클릭됨")
-        // 필터 적용 기능 추가 가능
+        ///TODO - 필터 적용 기능 추가 가능
     }
 }

--- a/Ting/Search/SearchVC.swift
+++ b/Ting/Search/SearchVC.swift
@@ -7,10 +7,10 @@
 
 import UIKit
 
-
-/// 검색 및 필터 화면을 관리하는 뷰컨트롤러
-class SearchVC: UIViewController {
+/// 검색 및 카테고리 모달을 관리하는 뷰컨트롤러
+final class SearchVC: UIViewController {
     
+    // 검색 뷰
     private let searchView = SearchView()
     
     // MARK: - View Lifecycle
@@ -25,24 +25,14 @@ class SearchVC: UIViewController {
     
     // MARK: - 버튼 액션 설정
     private func setupActions() {
-        
-        // 모든 카테고리 버튼에 액션 추가
-        searchView.categoryButtons.forEach { button in
-            button.addTarget(self, action: #selector(categoryButtonTapped), for: .touchUpInside)
+        searchView.categorySelectButton.addTarget(self, action: #selector(categorySelectButtonTapped), for: .touchUpInside)
+    }     
+    
+    @objc private func categorySelectButtonTapped() {
+        let modalVC = SearchSelectModalVC()
+        if let sheet = modalVC.sheetPresentationController {
+            sheet.detents = [.medium()]
         }
-        
-        searchView.applyFilterButton.addTarget(self, action: #selector(applyFilterTapped), for: .touchUpInside)
-    }
-    
-    // MARK: - 버튼 클릭 이벤트
-    // 카테고리버튼 배경색 & 글자색 변경
-    @objc private func categoryButtonTapped(_ sender: UIButton) {
-        sender.isSelected.toggle()
-    }
-    
-    // 적용버튼
-    @objc private func applyFilterTapped() {
-        print("필터 적용 버튼 클릭됨")
-        ///TODO - 필터 적용 기능 추가 가능
+        present(modalVC, animated: true)
     }
 }

--- a/Ting/Search/SearchView.swift
+++ b/Ting/Search/SearchView.swift
@@ -1,5 +1,5 @@
 //
-//  SearchV.swift
+//  SearchView.swift
 //  Ting
 //
 //  Created by Sol on 1/22/25.

--- a/Ting/Search/SearchView.swift
+++ b/Ting/Search/SearchView.swift
@@ -24,8 +24,8 @@ final class SearchView: UIView {
     
     // 카테고리 선택 버튼
     let categorySelectButton = UIButton(type: .system).then {
-        $0.setTitle("상세설정", for: .normal)
-        $0.titleLabel?.font = .systemFont(ofSize: 14, weight: .medium)
+        $0.setTitle("필터설정", for: .normal)
+        $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .medium)
         $0.tintColor = .deepCocoa
     }
     

--- a/Ting/Search/SearchView.swift
+++ b/Ting/Search/SearchView.swift
@@ -21,7 +21,7 @@ final class SearchView: UIView {
     
     // 카테고리 목록
     let categories: [(String, [String])] = [
-        ("구인/구직", ["구인", "구직"]),
+        ("게시글 구분", ["팀원모집", "팀 구함"]),
         ("직무", ["개발", "기획", "디자인", "마케터", "데이터"]),
         ("시급성", ["급함", "보통", "여유로움"]),
         ("아이디어 상황", ["구체적임", "모호함", "없음"]),
@@ -107,8 +107,8 @@ final class SearchView: UIView {
                 $0.distribution = .fillProportionally
             }
             
-            for item in items {
-                let button = createFilterButton(title: item)
+            for str in items {
+                let button = createCategoryButtons(title: str)
                 categoryButtons.append(button)
                 buttonStackView.addArrangedSubview(button)
             }
@@ -135,12 +135,12 @@ final class SearchView: UIView {
         }
     }
     
-    // MARK: - 필터 버튼 생성
-    private func createFilterButton(title: String) -> UIButton {
+    // MARK: - 카테고리 버튼 생성
+    private func createCategoryButtons(title: String) -> UIButton {
         let button = CustomTag(
             title: title,
             /// TODO - 글씨, 테두리 색상 고민
-            titleColor: .brownText,
+            titleColor: .primary,
             strokeColor: .secondary,
             backgroundColor: .white,
             isButton: true

--- a/Ting/Search/SearchView.swift
+++ b/Ting/Search/SearchView.swift
@@ -15,36 +15,40 @@ final class SearchView: UIView {
     // 🔍 검색창
     let searchBar = UISearchBar().then {
         $0.placeholder = "검색어를 입력하세요"
-        $0.searchBarStyle = .minimal
-        $0.backgroundColor = .clear
+        $0.searchBarStyle = .default
+        $0.backgroundColor = .white
+        $0.layer.borderWidth = 0.5
+        $0.layer.borderColor = UIColor.secondary.cgColor
+        $0.layer.cornerRadius = 8
     }
     
-    // 카테고리 목록
-    let categories: [(String, [String])] = [
-        ("게시글 구분", ["팀원모집", "팀 구함"]),
-        ("직무", ["개발", "기획", "디자인", "마케터", "데이터"]),
-        ("시급성", ["급함", "보통", "여유로움"]),
-        ("아이디어 상황", ["구체적임", "모호함", "없음"]),
-        ("경험", ["처음 입문", "재직중", "휴직중", "취준중"])
-    ]
-    
-    // 카테고리별 StackView 담을 스크롤 뷰
-    private let scrollView = UIScrollView().then {
-        $0.showsVerticalScrollIndicator = false
+    // 카테고리 선택 버튼
+    let categorySelectButton = UIButton(type: .system).then {
+        $0.setTitle("상세설정", for: .normal)
+        $0.titleLabel?.font = .systemFont(ofSize: 14, weight: .medium)
+        $0.tintColor = .deepCocoa
     }
     
-    private let contentView = UIView()
-    
-    // 모든 카테고리 버튼을 담을 배열
-    var categoryButtons: [UIButton] = []
-    
-    // 필터 적용 버튼
-    let applyFilterButton = UIButton().then {
-        $0.setTitle("필터 적용하기", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = .primary
-        $0.layer.cornerRadius = 10
+    // 카테고리 선택 후 생김
+    lazy var selectedCategoryStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 8
+        $0.distribution = .fillProportionally
     }
+    
+    // 검색 결과 리스트 표시
+    lazy var collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 20
+        layout.sectionInset = UIEdgeInsets(top: 20, left: 30, bottom: 0, right: 30)
+        layout.itemSize = CGSize(width: UIScreen.main.bounds.width - 60, height: 180)
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        //        collectionView.register(MainViewCell.self, forCellWithReuseIdentifier: MainViewCell.id)
+        collectionView.backgroundColor = .background
+        return collectionView
+    }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -58,93 +62,32 @@ final class SearchView: UIView {
     // MARK: - UI 설정
     private func setupUI() {
         backgroundColor = .background
-        
-        addSubview(searchBar)
-        addSubview(scrollView)
-        addSubview(applyFilterButton)
-        
-        scrollView.addSubview(contentView)
+        [
+            searchBar,
+            categorySelectButton,
+            selectedCategoryStackView,
+            collectionView
+        ].forEach { addSubview($0) }
         
         searchBar.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide).offset(10)
             $0.leading.trailing.equalToSuperview().inset(16)
         }
         
-        scrollView.snp.makeConstraints {
-            $0.top.equalTo(searchBar.snp.bottom).offset(10)
-            $0.leading.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalTo(applyFilterButton.snp.top).offset(-20)
+        categorySelectButton.snp.makeConstraints {
+            $0.top.equalTo(searchBar.snp.bottom).offset(4)
+            $0.leading.equalTo(searchBar.snp.leading).offset(4)
         }
         
-        contentView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-            $0.width.equalTo(scrollView.snp.width)
+        selectedCategoryStackView.snp.makeConstraints {
+            $0.centerY.equalTo(categorySelectButton)
+            $0.leading.equalTo(categorySelectButton.snp.trailing).offset(8)
         }
         
-        applyFilterButton.snp.makeConstraints {
-            $0.bottom.equalTo(safeAreaLayoutGuide).offset(-10)
-            $0.leading.trailing.equalToSuperview().inset(16)
-            $0.height.equalTo(50)
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(categorySelectButton.snp.bottom).offset(8)
+            $0.bottom.equalTo(safeAreaLayoutGuide)
+            $0.horizontalEdges.equalTo(safeAreaLayoutGuide)
         }
-        
-        setupCategoryButtons()
-    }
-    
-    // MARK: - 카테고리 버튼 동적 생성
-    private func setupCategoryButtons() {
-        var previousView: UIView? = nil
-        
-        for (category, items) in categories {
-            let categoryLabel = UILabel().then {
-                $0.text = category
-                $0.font = UIFont.boldSystemFont(ofSize: 16)
-                $0.textColor = .deepCocoa // 카테고리 주제 글자 색상
-            }
-            
-            let buttonStackView = UIStackView().then {
-                $0.axis = .horizontal
-                $0.spacing = 8
-                $0.distribution = .fillProportionally
-            }
-            
-            for str in items {
-                let button = createCategoryButtons(title: str)
-                categoryButtons.append(button)
-                buttonStackView.addArrangedSubview(button)
-            }
-            
-            contentView.addSubview(categoryLabel)
-            contentView.addSubview(buttonStackView)
-            
-            categoryLabel.snp.makeConstraints {
-                $0.top.equalTo(previousView?.snp.bottom ?? contentView.snp.top).offset(20)
-                $0.leading.equalToSuperview()
-            }
-            
-            buttonStackView.snp.makeConstraints {
-                $0.top.equalTo(categoryLabel.snp.bottom).offset(10)
-                $0.leading.equalToSuperview()
-            }
-            
-            previousView = buttonStackView
-        }
-        
-        // 마지막 요소의 하단을 contentView에 맞춤
-        previousView?.snp.makeConstraints {
-            $0.bottom.equalToSuperview().offset(-20)
-        }
-    }
-    
-    // MARK: - 카테고리 버튼 생성
-    private func createCategoryButtons(title: String) -> UIButton {
-        let button = CustomTag(
-            title: title,
-            /// TODO - 글씨, 테두리 색상 고민
-            titleColor: .primary,
-            strokeColor: .secondary,
-            backgroundColor: .white,
-            isButton: true
-        )
-        return button
     }
 }


### PR DESCRIPTION
## 변경사항
- 기존 서치뷰에 커스텀 컬러, 태그버튼 적용
- 버튼액션 로직 뷰컨으로 이동
- 태그 길이 조정

## 주요내용
- 커스텀컬러, 태그버튼 적용
- 태그 길이 조정

## 스크린샷

<img width="400" alt="" src="https://github.com/user-attachments/assets/41b7a3e6-3428-464d-9a0f-8ce9d5604312" />

## 추가계획
- 태그 타이틀 색상 고민 (스크린샷 참고)
- 구인/구직 : .brownText
- 직무 : .primary
- 검색 시 어떤 태그 넣을지 ( 현재 임시상태)
- 적용하기 버튼 모양, inset 고민

Resolves: #30 