### PR TITLE
Feat: MyPage, 회원정보 수정, 탈퇴 UI 구현 완료

### DIFF
--- a/Ting/MyPage/DeleteInfoVC.swift
+++ b/Ting/MyPage/DeleteInfoVC.swift
@@ -16,7 +16,7 @@ class DeleteInfoVC: UIViewController {
         $0.text = "회원 탈퇴"
         $0.textColor = .brownText
         $0.textAlignment = .left
-        $0.font = .boldSystemFont(ofSize: 20)
+        $0.font = .boldSystemFont(ofSize: 30)
     }
     private let cardView = UIView().then {
         $0.backgroundColor = .white
@@ -26,25 +26,46 @@ class DeleteInfoVC: UIViewController {
         $0.layer.shadowOffset = CGSize(width: 0, height: 4)
         $0.layer.shadowRadius = 6
     }
-    private let label = UILabel().then {
+    private let policyTitle = UILabel().then {
         $0.text = "회원 탈퇴 안내"
         $0.textColor = .brownText
         $0.textAlignment = .left
-        $0.font = .boldSystemFont(ofSize: 15)
+        $0.font = .boldSystemFont(ofSize: 20)
     }
-    private let label2 = UILabel().then {
-        $0.text = "블머낭러미;나어리"
+    private let policyDetail = UILabel().then {
+        $0.text = "회원 탈퇴 안내 약관이 들어올 자리"
         $0.textColor = .deepCocoa
         $0.textAlignment = .left
     }
-    private let button = UIButton().then {
-        $0.setTitle("회원탈퇴", for: .normal)
+    private let checkIcon = UIImageView().then {
+        $0.image = UIImage(systemName: "checkmark.circle.fill")
+        $0.tintColor = .grayCloud // 기본 비활성화 색상
+        $0.isUserInteractionEnabled = true // 사용자 터치 가능하도록 설정
+    }
+    private let agreement = UILabel().then {
+        $0.text = "약관을 확인했으며, 회원 탈퇴에 동의합니다"
+        $0.font = .boldSystemFont(ofSize: 18)
+        $0.textColor = .deepCocoa
+        $0.textAlignment = .left
+    }
+    // 현재 체크 상태 저장
+    private var isChecked = false {
+        didSet {
+            checkIcon.tintColor = isChecked ? .accent : .grayCloud
+        }
+    }
+    private lazy var stackView = UIStackView(arrangedSubviews: [checkIcon, agreement]).then {
+        $0.axis = .horizontal
+        $0.spacing = 5
+        $0.distribution = .fillProportionally
+    }
+    private let deleteBtn = UIButton().then {
+        $0.setTitle("회원 탈퇴", for: .normal)
         $0.backgroundColor = .primary
         $0.layer.cornerRadius = 8
-        $0.layer.shadowColor = UIColor.black.cgColor
-        $0.layer.shadowOpacity = 0.1
-        $0.layer.shadowOffset = CGSize(width: 0, height: 4)
-        $0.layer.shadowRadius = 6
+        $0.titleLabel?.font = UIFont.boldSystemFont(ofSize: 20)
+        
+        $0.addTarget(self, action: #selector(deleteBtnTapped), for: .touchUpInside)
     }
     
     // MARK: - LifeCycle
@@ -52,17 +73,8 @@ class DeleteInfoVC: UIViewController {
         super.viewDidLoad()
         
         configureUI()
+        setupTapGesture()
     }
-//    // 네비게이션 바 가리기
-//    override func viewWillAppear(_ animated: Bool) {
-//        super.viewWillAppear(animated)
-//        navigationController?.setNavigationBarHidden(true, animated: false) // 네비게이션 바 숨기기
-//    }
-//    // 다른 뷰로 이동할 때 다시 보이기
-//    override func viewWillDisappear(_ animated: Bool) {
-//        super.viewWillDisappear(animated)
-//        navigationController?.setNavigationBarHidden(false, animated: false) // 원래대로 복구
-//    }
     
     // MARK: - Configure UI
     private func configureUI() {
@@ -74,42 +86,65 @@ class DeleteInfoVC: UIViewController {
             $0.leading.equalToSuperview().offset(10)
             $0.centerX.equalToSuperview()
         }
-        
         view.addSubview(cardView)
         cardView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(20) // 상단에서 여백 증가
             $0.centerX.equalToSuperview() // 화면 중앙 정렬
             $0.width.equalToSuperview().inset(10) // 카드뷰 너비 조정 (직접 설정)
         }
-        
-        // 내부 요소 추가
-        cardView.addSubview(label)
-        label.snp.makeConstraints {
+        cardView.addSubview(policyTitle)
+        policyTitle.snp.makeConstraints {
             $0.top.equalToSuperview().offset(10)
             $0.leading.equalToSuperview().offset(10)
             $0.height.equalTo(30)
         }
-        
-        cardView.addSubview(label2)
-        label2.snp.makeConstraints {
-            $0.top.equalTo(label.snp.bottom).offset(10) // 간격 조정
+        cardView.addSubview(policyDetail)
+        policyDetail.snp.makeConstraints {
+            $0.top.equalTo(policyTitle.snp.bottom).offset(10)
             $0.leading.equalToSuperview().offset(10)
             $0.height.equalTo(30)
         }
-        
         // cardView 크기 자동 조정
         cardView.snp.makeConstraints {
-            $0.bottom.equalTo(label2.snp.bottom).offset(20) // 크기 최소화
+            $0.bottom.equalTo(policyDetail.snp.bottom).offset(20)
         }
-        
+        view.addSubview(stackView)
+        stackView.snp.makeConstraints {
+            $0.top.equalTo(cardView.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(10)
+            $0.centerX.equalToSuperview()
+        }
+        checkIcon.snp.makeConstraints {
+            $0.width.height.equalTo(20)
+
+        }
         // 버튼 추가 및 위치 조정
-        view.addSubview(button)
-        button.snp.makeConstraints {
-            $0.top.equalTo(cardView.snp.bottom).offset(20)
+        view.addSubview(deleteBtn)
+        deleteBtn.snp.makeConstraints {
+            $0.top.equalTo(stackView.snp.bottom).offset(20)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(200) // 버튼 너비 설정
-            $0.height.equalTo(40) // 버튼 높이 설정
+            $0.height.equalTo(50) // 버튼 높이 설정
         }
+    }
+    
+    // 체크 아이콘에 클릭 이벤트 추가
+    private func setupTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(toggleCheck))
+        checkIcon.addGestureRecognizer(tapGesture)
+    }
+    
+    // 체크 상태 변경 (토글)
+    @objc
+    private func toggleCheck() {
+        isChecked.toggle()
+    }
+    
+    // MARK: - Button Actions
+    @objc
+    private func deleteBtnTapped() {
+        let firstPage = SignUpViewController()
+        self.navigationController?.pushViewController(firstPage, animated: true)
     }
 }
 
@@ -117,8 +152,6 @@ class DeleteInfoVC: UIViewController {
 // MARK: - TODO
 /*
  
- - 라디오 버튼
- - 버튼 액션
- - 네비게이션바 논의
+- 체크아이콘 클릭시에만 탈퇴 버튼 활성화
  
 */

--- a/Ting/MyPage/DeleteInfoVC.swift
+++ b/Ting/MyPage/DeleteInfoVC.swift
@@ -11,6 +11,13 @@ import Then
 
 class DeleteInfoVC: UIViewController {
     
+    //MARK: - UI Components
+    private let titleLabel = UILabel().then {
+        $0.text = "회원 탈퇴"
+        $0.textColor = .brownText
+        $0.textAlignment = .left
+        $0.font = .boldSystemFont(ofSize: 20)
+    }
     private let cardView = UIView().then {
         $0.backgroundColor = .white
         $0.layer.cornerRadius = 12
@@ -19,55 +26,74 @@ class DeleteInfoVC: UIViewController {
         $0.layer.shadowOffset = CGSize(width: 0, height: 4)
         $0.layer.shadowRadius = 6
     }
-    
     private let label = UILabel().then {
         $0.text = "회원 탈퇴 안내"
         $0.textColor = .brownText
         $0.textAlignment = .left
         $0.font = .boldSystemFont(ofSize: 15)
     }
-    
     private let label2 = UILabel().then {
         $0.text = "블머낭러미;나어리"
         $0.textColor = .deepCocoa
         $0.textAlignment = .left
     }
-    
     private let button = UIButton().then {
         $0.setTitle("회원탈퇴", for: .normal)
         $0.backgroundColor = .primary
         $0.layer.cornerRadius = 8
+        $0.layer.shadowColor = UIColor.black.cgColor
+        $0.layer.shadowOpacity = 0.1
+        $0.layer.shadowOffset = CGSize(width: 0, height: 4)
+        $0.layer.shadowRadius = 6
     }
     
+    // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
         configureUI()
     }
+//    // 네비게이션 바 가리기
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//        navigationController?.setNavigationBarHidden(true, animated: false) // 네비게이션 바 숨기기
+//    }
+//    // 다른 뷰로 이동할 때 다시 보이기
+//    override func viewWillDisappear(_ animated: Bool) {
+//        super.viewWillDisappear(animated)
+//        navigationController?.setNavigationBarHidden(false, animated: false) // 원래대로 복구
+//    }
     
+    // MARK: - Configure UI
     private func configureUI() {
         view.backgroundColor = .background
         
-        // cardView 크기 조정 및 위치 변경
+        view.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(10)
+            $0.leading.equalToSuperview().offset(10)
+            $0.centerX.equalToSuperview()
+        }
+        
         view.addSubview(cardView)
         cardView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(50) // 상단에서 여백 증가
+            $0.top.equalTo(titleLabel.snp.bottom).offset(20) // 상단에서 여백 증가
             $0.centerX.equalToSuperview() // 화면 중앙 정렬
-            $0.width.equalToSuperview().inset(10) // ✅ 카드뷰 너비 조정 (직접 설정)
+            $0.width.equalToSuperview().inset(10) // 카드뷰 너비 조정 (직접 설정)
         }
         
         // 내부 요소 추가
         cardView.addSubview(label)
         label.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.leading.equalToSuperview().offset(20)
+            $0.top.equalToSuperview().offset(10)
+            $0.leading.equalToSuperview().offset(10)
             $0.height.equalTo(30)
         }
         
         cardView.addSubview(label2)
         label2.snp.makeConstraints {
             $0.top.equalTo(label.snp.bottom).offset(10) // 간격 조정
-            $0.leading.equalToSuperview().offset(20)
+            $0.leading.equalToSuperview().offset(10)
             $0.height.equalTo(30)
         }
         
@@ -88,3 +114,11 @@ class DeleteInfoVC: UIViewController {
 }
 
 
+// MARK: - TODO
+/*
+ 
+ - 라디오 버튼
+ - 버튼 액션
+ - 네비게이션바 논의
+ 
+*/

--- a/Ting/MyPage/EditCustomView.swift
+++ b/Ting/MyPage/EditCustomView.swift
@@ -18,16 +18,25 @@ class EditCustomView: UIView {
         $0.textAlignment = .left
     }
     private let textField = UITextField().then {
-        $0.borderStyle = .roundedRect
-        $0.backgroundColor = .black
+        $0.backgroundColor = .white
         $0.textColor = .brownText
+        $0.borderStyle = .none // 기본 테두리를 제거
+        $0.layer.borderWidth = 1.0 // 테두리 두께 설정
+        $0.layer.borderColor = UIColor.primary.cgColor // 테두리 색상 설정
+        $0.layer.cornerRadius = 8 // 둥근 모서리 설정 (선택 사항)
     }
     
     // MARK: - 초기화
     init(labelText: String, placeholder: String) {
         super.init(frame: .zero)
         label.text = labelText
-        textField.placeholder = placeholder
+        //textField.placeholder = placeholder
+        textField.attributedPlaceholder = NSAttributedString(
+            string: placeholder,
+            attributes: [
+                .foregroundColor: UIColor.grayCloud // Placeholder 색상 변경
+            ]
+        )
         setupView()
     }
     
@@ -44,7 +53,7 @@ class EditCustomView: UIView {
         
         addSubview(stackView)
         stackView.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(10)
+            $0.edges.equalToSuperview().inset(5)
         }
         label.snp.makeConstraints {
             $0.height.equalTo(24)
@@ -56,7 +65,7 @@ class EditCustomView: UIView {
     
     // MARK: - 크기 지정
     override var intrinsicContentSize: CGSize {
-        return CGSize(width: UIView.noIntrinsicMetric, height: 70) // 기본 높이를 70으로 줄이기
+        return CGSize(width: UIView.noIntrinsicMetric, height: 50) // stackView간의 기본 높이 설정
     }
 }
 

--- a/Ting/MyPage/EditCustomView.swift
+++ b/Ting/MyPage/EditCustomView.swift
@@ -17,13 +17,18 @@ class EditCustomView: UIView {
         $0.font = .boldSystemFont(ofSize: 15)
         $0.textAlignment = .left
     }
-    private let textField = UITextField().then {
+    public let textField = UITextField().then {
         $0.backgroundColor = .white
         $0.textColor = .brownText
         $0.borderStyle = .none // 기본 테두리를 제거
         $0.layer.borderWidth = 1.0 // 테두리 두께 설정
         $0.layer.borderColor = UIColor.primary.cgColor // 테두리 색상 설정
         $0.layer.cornerRadius = 8 // 둥근 모서리 설정 (선택 사항)
+        
+        // MARK: 키보드 설정
+        $0.keyboardType = .default
+        $0.clearButtonMode = .whileEditing
+        $0.returnKeyType = .done
     }
     
     // MARK: - 초기화

--- a/Ting/MyPage/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfoVC.swift
@@ -50,16 +50,16 @@ class EditInfoVC: UIViewController {
         
         configureUI()
     }
-    // 네비게이션 바 가리기
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(true, animated: false)
-    }
-    // 다른 뷰로 이동할 때 다시 보이기
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        navigationController?.setNavigationBarHidden(false, animated: false)
-    }
+//    // 네비게이션 바 가리기
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//        navigationController?.setNavigationBarHidden(true, animated: false)
+//    }
+//    // 다른 뷰로 이동할 때 다시 보이기
+//    override func viewWillDisappear(_ animated: Bool) {
+//        super.viewWillDisappear(animated)
+//        navigationController?.setNavigationBarHidden(false, animated: false)
+//    }
     
     // MARK: - Configure UI
     private func configureUI() {

--- a/Ting/MyPage/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfoVC.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Then
 
-class EditInfoVC: UIViewController {
+class EditInfoVC: UIViewController, UITextFieldDelegate {
     
     // MARK: - UI Components
     private let titleLabel = UILabel().then {
@@ -47,12 +47,17 @@ class EditInfoVC: UIViewController {
         
         $0.addTarget(self, action: #selector(saveBtnTapped), for: .touchUpInside)
     }
-
+    
     // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
         configureUI()
+        
+        // 키보드 설정 위해 delegate 적용
+        [nameField, skillStackField, toolField, workStyleField, locationField, interestField].forEach {
+            $0.textField.delegate = self
+        }
     }
     
     // MARK: - Configure UI
@@ -94,6 +99,19 @@ class EditInfoVC: UIViewController {
     private func saveBtnTapped() {
         self.navigationController?.popViewController(animated: true) // pop으로 현재뷰 삭제되고 이전뷰로 이동
     }
+    
+    //MARK: 키보드 설정
+    //다른 공간 터치시 키보드 사라짐
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
+        super.touchesBegan(touches, with: event)
+    }
+    
+    // MARK: - Return 키를 눌렀을 때 키보드 내리기
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder() // 키보드 내림
+        return true
+    }
 }
 
 
@@ -102,5 +120,6 @@ class EditInfoVC: UIViewController {
  
  - 수정 취소 버튼?
  - 수정완료 얼럿 띄우고 확인시 이동
+ - 클리어버튼 색상 변경 (커스텀에서 확인)
  
 */

--- a/Ting/MyPage/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfoVC.swift
@@ -15,7 +15,7 @@ class EditInfoVC: UIViewController {
     private let titleLabel = UILabel().then {
         $0.text = "회원정보 수정"
         $0.textColor = .brownText
-        $0.font = .boldSystemFont(ofSize: 20)
+        $0.font = .boldSystemFont(ofSize: 30)
         $0.textAlignment = .left
     }
     
@@ -30,18 +30,22 @@ class EditInfoVC: UIViewController {
         $0.distribution = .fillEqually
     }
     
-    private let nameField = EditCustomView(labelText: "이름", placeholder: "이름을 입력하세요")
-    private let skillStackField = EditCustomView(labelText: "기술 스택", placeholder: "예: Swift, Kotlin")
-    private let toolField = EditCustomView(labelText: "사용 툴", placeholder: "예: Xcode, Android Studio")
-    private let workStyleField = EditCustomView(labelText: "협업 방식", placeholder: "예: 온라인, 오프라인, 무관")
-    private let locationField = EditCustomView(labelText: "지역", placeholder: "거주 지역을 입력하세요")
-    private let interestField = EditCustomView(labelText: "관심사", placeholder: "관심 있는 분야를 입력하세요")
+    private let nameField = EditCustomView(labelText: "이름", placeholder: "  이름을 입력하세요")
+    private let skillStackField = EditCustomView(labelText: "기술 스택", placeholder: "  예: Swift, Kotlin")
+    private let toolField = EditCustomView(labelText: "사용 툴", placeholder: "  예: Xcode, Android Studio")
+    private let workStyleField = EditCustomView(labelText: "협업 방식", placeholder: "  예: 온라인, 오프라인, 무관")
+    private let locationField = EditCustomView(labelText: "지역", placeholder: "  거주 지역을 입력하세요")
+    private let interestField = EditCustomView(labelText: "관심사", placeholder: "  관심 있는 분야를 입력하세요")
     
     
-    private let saveButton = UIButton().then {
-        $0.setTitle("저장", for: .normal)
-        $0.backgroundColor = .brownText
+    private let saveButton = UIButton(type: .system).then {
+        $0.setTitle("저장하기", for: .normal)
+        $0.backgroundColor = .primary
         $0.layer.cornerRadius = 8
+        $0.setTitleColor(.white, for: .normal)
+        $0.titleLabel?.font = UIFont.boldSystemFont(ofSize: 20)
+        
+        $0.addTarget(self, action: #selector(saveBtnTapped), for: .touchUpInside)
     }
 
     // MARK: - LifeCycle
@@ -50,16 +54,6 @@ class EditInfoVC: UIViewController {
         
         configureUI()
     }
-//    // 네비게이션 바 가리기
-//    override func viewWillAppear(_ animated: Bool) {
-//        super.viewWillAppear(animated)
-//        navigationController?.setNavigationBarHidden(true, animated: false)
-//    }
-//    // 다른 뷰로 이동할 때 다시 보이기
-//    override func viewWillDisappear(_ animated: Bool) {
-//        super.viewWillDisappear(animated)
-//        navigationController?.setNavigationBarHidden(false, animated: false)
-//    }
     
     // MARK: - Configure UI
     private func configureUI() {
@@ -94,6 +88,12 @@ class EditInfoVC: UIViewController {
             $0.height.equalTo(50)
         }
     }
+    
+    // MARK: - Button Actions
+    @objc
+    private func saveBtnTapped() {
+        self.navigationController?.popViewController(animated: true) // pop으로 현재뷰 삭제되고 이전뷰로 이동
+    }
 }
 
 
@@ -101,7 +101,6 @@ class EditInfoVC: UIViewController {
 /*
  
  - 수정 취소 버튼?
- - 키보드 설정
- - 버튼 액션
+ - 수정완료 얼럿 띄우고 확인시 이동
  
 */

--- a/Ting/MyPage/MyPageCustomVIew.swift
+++ b/Ting/MyPage/MyPageCustomVIew.swift
@@ -1,0 +1,62 @@
+//
+//  MyPageCustomVIew.swift
+//  Ting
+//
+//  Created by 이재건 on 1/26/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class MyPageCustomView: UIView {
+    
+    // MARK: - UI Components
+    private let titleLabel = UILabel().then {
+        $0.textColor = .brownText
+        $0.font = .boldSystemFont(ofSize: 18)
+        $0.textAlignment = .left
+    }
+    private let detailLabel = UILabel().then {
+        $0.textColor = .deepCocoa
+        $0.font = .boldSystemFont(ofSize: 15)
+        $0.textAlignment = .left
+    }
+    
+    
+    // MARK: - 초기화
+    init(title: String, detail: String) {
+        super.init(frame: .zero)
+        titleLabel.text = title
+        detailLabel.text = detail
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - setUpUI
+    private func setupView() {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, detailLabel]).then {
+            $0.axis = .vertical
+            $0.spacing = 3
+        }
+        
+        addSubview(stackView)
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(10)
+        }
+        titleLabel.snp.makeConstraints {
+            $0.height.equalTo(24)
+        }
+        detailLabel.snp.makeConstraints {
+            $0.height.equalTo(36)
+        }
+    }
+    
+    // MARK: - 크기 지정
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: UIView.noIntrinsicMetric, height: 30)
+    }
+}

--- a/Ting/MyPage/MyPageMainVC.swift
+++ b/Ting/MyPage/MyPageMainVC.swift
@@ -11,23 +11,161 @@ import Then
 
 class MyPageMainVC: UIViewController {
     
-    private let btn2 = UIButton(type: .system).then {
-        $0.setTitle("웹", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = .black
-        $0.layer.cornerRadius = 5
-        
-        
+    // MARK: - UI Components
+    private let titleLabel = UILabel().then {
+        $0.text = "마이페이지"
+        $0.textAlignment = .left
+        $0.textColor = .brownText
+        $0.font = .boldSystemFont(ofSize: 30)
     }
     
+    // cardView 1에 들어갈 내용들
+    private let cardView1 = UIView().then {
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 12
+        $0.layer.shadowColor = UIColor.black.cgColor
+        $0.layer.shadowOpacity = 0.1
+        $0.layer.shadowOffset = CGSize(width: 0, height: 4)
+        $0.layer.shadowRadius = 6
+    }
+    private let nickName = UILabel().then {
+        $0.text = "홍길동"
+        $0.textColor = .brownText
+        $0.font = .boldSystemFont(ofSize: 20)
+        $0.textAlignment = .left
+    }
+    private let role = UILabel().then {
+        $0.text = "개발자"
+        $0.textColor = .deepCocoa
+        $0.font = .systemFont(ofSize: 15)
+        $0.textAlignment = .left
+    }
+    private lazy var stackView1 = UIStackView(arrangedSubviews: [nickName, role]).then {
+        $0.axis = .vertical
+        $0.spacing = 10
+        $0.distribution = .fillEqually
+    }
+    
+    // cardView 2에 들어갈 내용들
+    private let cardView2 = UIView().then {
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 12
+        $0.layer.shadowColor = UIColor.black.cgColor
+        $0.layer.shadowOpacity = 0.1
+        $0.layer.shadowOffset = CGSize(width: 0, height: 4)
+        $0.layer.shadowRadius = 6
+    }
+    
+    private let nameField = MyPageCustomView(title: "이름", detail: "이름을 입력하세요")
+    private let skillStackField = MyPageCustomView(title: "기술 스택", detail: "예: Swift, Kotlin")
+    private let toolField = MyPageCustomView(title: "사용 툴", detail: "예: Xcode, Android Studio")
+    private let workStyleField = MyPageCustomView(title: "협업 방식", detail: "예: 온라인, 오프라인, 무관")
+    private let locationField = MyPageCustomView(title: "지역", detail: "거주 지역을 입력하세요")
+    private let interestField = MyPageCustomView(title: "관심사", detail: "관심 있는 분야를 입력하세요")
+    
+    private let editBtn = UIButton(type: .system).then {
+        $0.setTitle("회원정보 수정", for: .normal)
+        $0.layer.cornerRadius = 8
+        $0.backgroundColor = .primary
+        $0.setTitleColor(.white, for: .normal)
+        
+        $0.addTarget(self, action: #selector(editBtnTapped), for: .touchUpInside)
+    }
+    private let deleteBtn = UIButton(type: .system).then {
+        $0.setTitle("회원탈퇴", for: .normal)
+        $0.layer.cornerRadius = 8
+        $0.backgroundColor = .primary
+        $0.setTitleColor(.white, for: .normal)
+        
+        $0.addTarget(self, action: #selector(deleteBtnTapped), for: .touchUpInside)
+    }
+    private lazy var stackView2 = UIStackView(arrangedSubviews: [
+        nameField,
+        skillStackField,
+        toolField,
+        workStyleField,
+        locationField,
+        interestField
+    ]).then {
+        $0.axis = .vertical
+        $0.spacing = 2
+        $0.distribution = .fillEqually
+    }
+    private lazy var btnStackView = UIStackView(arrangedSubviews: [editBtn, deleteBtn]).then {
+        $0.axis = .horizontal
+        $0.spacing = 10
+        $0.distribution = .fillEqually
+    }
+    
+    // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
+    
+        configureUI()
+    }
+    // 네비게이션 바 가리기
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false) // 네비게이션 바 숨기기
+    }
+    // 다른 뷰로 이동할 때 다시 보이기
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: false) // 원래대로 복구
+    }
+    
+    // MARK: - configure UI
+    private func configureUI() {
+        view.backgroundColor = .background
         
-        view.addSubview(btn2)
-        btn2.snp.makeConstraints {
-            $0.center.equalToSuperview()
+        view.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(15)
+            $0.leading.equalToSuperview().offset(10)
+            $0.centerX.equalToSuperview()
         }
-        
+        view.addSubview(cardView1)
+        cardView1.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(10)
+        }
+        cardView1.addSubview(stackView1)
+        stackView1.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(10)
+        }
+        view.addSubview(cardView2)
+        cardView2.snp.makeConstraints {
+            $0.top.equalTo(cardView1.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(10)
+        }
+        cardView2.addSubview(stackView2)
+        stackView2.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(10)
+        }
+        view.addSubview(btnStackView)
+        btnStackView.snp.makeConstraints {
+            $0.top.equalTo(cardView2.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(10)
+            $0.centerX.equalToSuperview()
+        }
+        editBtn.snp.makeConstraints {
+            $0.height.equalTo(40)
+        }
+        deleteBtn.snp.makeConstraints {
+            $0.height.equalTo(40)
+        }
+     }
+    
+    // MARK: - Button Actions
+    @objc
+    private func editBtnTapped() {
+        let edit = EditInfoVC()
+        self.navigationController?.pushViewController(edit, animated: true)
+    }
+    @objc
+    private func deleteBtnTapped() {
+        let delete = DeleteInfoVC()
+        self.navigationController?.pushViewController(delete, animated: true)
     }
 }
 


### PR DESCRIPTION
# UI 구현 완료
## MyPage UI 구현 완료


<img width="568" alt="Image" src="https://github.com/user-attachments/assets/e78e68d3-5dee-457a-b879-2870a27987b4" />


- 카드뷰 두 개로 나누어 구현
- 커스텀 뷰 생성하여 label들을 생성할 때 코드를 간결하게 하고 코드의 재사용성을 높임
- 버튼 액션으로 회원정보 수정 및 회원탈퇴 뷰로 연결

### Todo
- 버튼 색 변경
- 폰트 변경

Resolves: #36

-----

## 회원정보 수정 UI 구현 완료


<img width="568" alt="Image" src="https://github.com/user-attachments/assets/43f52c0a-1e29-46ab-8486-e27bb68ece53" />


### Text Field 변경사항
- TextFiled의 테두리를 추가하고 색을 변경했습니다
- placeholder의 색을 변경했습니다.

### 버튼 액션
- 저장하기 버튼 클릭시 마이페이지로 돌아가게 구현하였습니다.

### 키보드 설정
- TextField 바깥의 다른곳을 탭하면 키보드가 내려가게 하였습니다.
- 입력을 마치고 return키를 클릭하면 키보드가 내려가게 하였습니다.

### Todo
 - 수정 취소 버튼?
 - 수정완료 얼럿 띄우고 확인시 이동
 - 클리어버튼 색상 변경 (커스텀에서 확인)

Resolves: #34

-----

## 회원 탈퇴 UI 구현 완료


<img width="524" alt="Image" src="https://github.com/user-attachments/assets/b5a91cff-5026-4686-b48a-a8a513f40519" />


### 변경사항
- 글자들의 크기를 변경했습니다.
- 버튼의 색을 변경했습니다
- 체크 버튼을 만들어서 회원 탈퇴에 동의한다는 것을 확인받도록 했습니다.

### Todo
 - 체크아이콘 클릭시에만 탈퇴 버튼 활성화

Resolves: #35 