### PR TITLE
Feat: 서치뷰에 메인뷰 셀 적용

### DIFF
--- a/Ting/Search/SearchVC.swift
+++ b/Ting/Search/SearchVC.swift
@@ -21,12 +21,14 @@ final class SearchVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupActions()
+        searchView.collectionView.dataSource = self
+        searchView.collectionView.delegate = self
     }
     
     // MARK: - 버튼 액션 설정
     private func setupActions() {
         searchView.categorySelectButton.addTarget(self, action: #selector(categorySelectButtonTapped), for: .touchUpInside)
-    }     
+    }
     
     @objc private func categorySelectButtonTapped() {
         let modalVC = SearchSelectModalVC()
@@ -34,5 +36,36 @@ final class SearchVC: UIViewController {
             sheet.detents = [.medium()]
         }
         present(modalVC, animated: true)
+    }
+}
+
+extension SearchVC: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        /// TODO - Rx 적용, 서버로 부터 데이터 받아오기 (몇개까지 받아올지, 페이징처리 할지 고민)
+        return 10
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainViewCell.identifier, for: indexPath) as? MainViewCell else {
+            return UICollectionViewCell()
+        }
+        
+        /// TODO - Rx 적용 ⭐️ 처음 진입시 검색된 거 0개, 검색 이후 셀 표시
+        cell.configure(
+            with: "제목 \(indexPath.row + 1)",
+            detail: " 내용 \(indexPath.row + 1)",
+            date: "2025.01.0\(indexPath.row % 9 + 1)",
+            tags: ["태그1", "태그2"]
+        )
+        return cell
+    }
+}
+
+extension SearchVC: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        let postDetailVC = PostDetailVC()
+        /// 서버로 부터 받아온 데이터 같이 넘기기 (Rx적용)
+        navigationController?.pushViewController(postDetailVC, animated: true)
     }
 }

--- a/Ting/Search/SearchView.swift
+++ b/Ting/Search/SearchView.swift
@@ -40,12 +40,14 @@ final class SearchView: UIView {
     lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
-        layout.minimumLineSpacing = 20
-        layout.sectionInset = UIEdgeInsets(top: 20, left: 30, bottom: 0, right: 30)
-        layout.itemSize = CGSize(width: UIScreen.main.bounds.width - 60, height: 180)
+        
+        /// TODO - 게시글 리스트와 마찬가지로 메인뷰 셀 모양 조정에 따라 변경 필요
+        layout.minimumLineSpacing = 0
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
+        layout.itemSize = CGSize(width: UIScreen.main.bounds.width - 20, height: 180)
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        //        collectionView.register(MainViewCell.self, forCellWithReuseIdentifier: MainViewCell.id)
+        collectionView.register(MainViewCell.self, forCellWithReuseIdentifier: MainViewCell.identifier)
         collectionView.backgroundColor = .background
         return collectionView
     }()


### PR DESCRIPTION
## 변경사항
- 서치뷰 컬렉션뷰에 셀 적용

## 주요내용
- 셀 적용

## 스크린샷

<img width="400" alt="" src="https://github.com/user-attachments/assets/04876e39-2c5c-4e9d-a577-05df78c47fac" />

<img width="400" alt="" src="https://github.com/user-attachments/assets/4bac0854-3d8f-400a-bcc0-8007f55cc735" />

## 추가계획, 고민
- 메인뷰 셀 모양 변경 시 코드 수정 필요
- 검색 전 화면 처음 **진입 시 셀 데이터 0개, 검색 이후 적용 기능** 구현 필요 (서버연결 이후)
- 필터 적용 후 **검색에 필터적용되는 기능** 구현 필요
- 적용한 **필터 필터설정 옆으로 or 아래에 태그 생기게** 기능 구현 필요

Resolves: #47 