### PR TITLE
Feat: 약관 동의, 회원가입 완료 후 탭바로 이동

### DIFF
--- a/Ting/SignUp/SignUpView/PermissionView.swift
+++ b/Ting/SignUp/SignUpView/PermissionView.swift
@@ -30,7 +30,7 @@ class PermissionView: UIView {
 
     // "다음" 버튼
     let nextButton = UIButton().then {
-        $0.setTitle("다음", for: .normal)
+        $0.setTitle("회원가입", for: .normal)
         $0.setTitleColor(.white, for: .normal)
         $0.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
         $0.backgroundColor = .primary
@@ -39,7 +39,7 @@ class PermissionView: UIView {
 
     // 약관 동의 안내 문구 (Tap Gesture를 이용해 텍스트 일부 클릭 가능)
     let agreementLabel = UILabel().then {
-        let fullText = "다음 버튼을 클릭으로, Ting 이용 약관에 동의합니다."
+        let fullText = "가입 버튼을 클릭으로, Ting 이용 약관에 동의합니다."
         let attributedString = NSMutableAttributedString(string: fullText)
         let range = (fullText as NSString).range(of: "이용 약관")
         attributedString.addAttribute(.foregroundColor, value: UIColor.accent, range: range)

--- a/Ting/SignUp/SignUpView/SignUpViewController.swift
+++ b/Ting/SignUp/SignUpView/SignUpViewController.swift
@@ -68,9 +68,9 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
                     print("이메일: \(user.email ?? "이메일 없음")")
                     
                     // 메인 화면으로 이동
-                    let mainVC = MainVC()
-                    mainVC.modalPresentationStyle = .fullScreen
-                    self.present(mainVC, animated: true)
+                    let tabBarController = TabBar()  // TabBar 인스턴스 생성
+                    tabBarController.modalPresentationStyle = .fullScreen
+                    self.present(tabBarController, animated: true)
                 }
             }
         }

--- a/Ting/SignUp/SignUpView/SignUpViewController.swift
+++ b/Ting/SignUp/SignUpView/SignUpViewController.swift
@@ -67,11 +67,10 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
                     print("유저 UID: \(user.uid)")
                     print("이메일: \(user.email ?? "이메일 없음")")
                     
-                    // 메인 화면으로 이동
-                    let tabBarController = TabBar()  // TabBar 인스턴스 생성
-                    tabBarController.modalPresentationStyle = .fullScreen
-                    self.present(tabBarController, animated: true)
-                }
+                    // TabBar로 완전히 전환 (루트 뷰 컨트롤러 변경)
+                    let tabBarController = TabBar()
+                    let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+                    sceneDelegate?.window?.rootViewController = tabBarController                }
             }
         }
     }

--- a/Ting/SignUp/SignUpView/TermsCell.swift
+++ b/Ting/SignUp/SignUpView/TermsCell.swift
@@ -34,7 +34,7 @@ class TermsCell: UITableViewCell {
     // 현재 체크 상태 저장
     private var isChecked = false {
         didSet {
-            checkIcon.tintColor = isChecked ? UIColor .accent : .gray
+            checkIcon.tintColor = isChecked ? UIColor.accent : .gray
         }
     }
     
@@ -79,6 +79,9 @@ class TermsCell: UITableViewCell {
     func configure(text: String, isRequired: Bool, isChecked: Bool) {
         termLabel.text = text
         self.isChecked = isChecked // 초기 상태 설정
+
+        // 특정 텍스트에 대해 화살표 숨기기
+        arrowIcon.isHidden = (text == "(필수) 만 14세 이상입니다")
     }
     
     // 체크 아이콘에 클릭 이벤트 추가

--- a/Ting/SignUp/SignUpView/TermsModalVC.swift
+++ b/Ting/SignUp/SignUpView/TermsModalVC.swift
@@ -77,7 +77,16 @@ class TermsModalViewController: UIViewController {
     }
     
     @objc private func nextTapped() {
-        dismiss(animated: true)  // 모달 닫기
+        guard let presentingVC = presentingViewController else {
+            print("presentingViewController가 nil입니다.")
+            return
+        }
+
+        dismiss(animated: true) {  // 모달을 닫은 후
+            let signUpVC = SignUpViewController()
+            signUpVC.modalPresentationStyle = .fullScreen
+            presentingVC.present(signUpVC, animated: true)  // 부모 뷰 컨트롤러에서 SignUpViewController로 이동
+        }
     }
 
     // 모든 항목이 체크되었는지 확인하고 버튼 상태 업데이트

--- a/Ting/SignUp/SignUpView/TermsModalVC.swift
+++ b/Ting/SignUp/SignUpView/TermsModalVC.swift
@@ -19,7 +19,6 @@ class TermsModalViewController: UIViewController {
         ("(필수) 만 14세 이상입니다", true, false),
         ("(필수) 서비스 이용약관", true, false),
         ("(필수) 개인정보 수집 및 이용에 대한 안내", true, false),
-        ("(선택) 개인정보 수집 및 이용에 대한 안내", false, false)
     ]
     
     override func viewDidLoad() {

--- a/Ting/SignUp/SignUpView/TermsModalVC.swift
+++ b/Ting/SignUp/SignUpView/TermsModalVC.swift
@@ -82,10 +82,11 @@ class TermsModalViewController: UIViewController {
             return
         }
 
-        dismiss(animated: true) {  // 모달을 닫은 후
+        dismiss(animated: true) {
+            // 루트 뷰 컨트롤러로 SignUpViewController 설정
+            let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
             let signUpVC = SignUpViewController()
-            signUpVC.modalPresentationStyle = .fullScreen
-            presentingVC.present(signUpVC, animated: true)  // 부모 뷰 컨트롤러에서 SignUpViewController로 이동
+            sceneDelegate?.window?.rootViewController = signUpVC
         }
     }
 

--- a/Ting/SignUp/SignUpView/TermsModalVC.swift
+++ b/Ting/SignUp/SignUpView/TermsModalVC.swift
@@ -26,6 +26,7 @@ class TermsModalViewController: UIViewController {
         setupUI()
         setupTableView()
         setupActions()
+        updateNextButtonState()  // 처음 화면 로드 시 버튼 비활성화
     }
     
     private func setupUI() {
@@ -71,10 +72,19 @@ class TermsModalViewController: UIViewController {
         // 모든 약관의 체크 상태를 변경
         terms = terms.map { ($0.0, $0.1, newState) }
         termsView.tableView.reloadData()
+        
+        updateNextButtonState()  // 상태 변경 후 버튼 업데이트
     }
     
     @objc private func nextTapped() {
         dismiss(animated: true)  // 모달 닫기
+    }
+
+    // 모든 항목이 체크되었는지 확인하고 버튼 상태 업데이트
+    private func updateNextButtonState() {
+        let allChecked = terms.allSatisfy { $0.2 }
+        termsView.nextButton.isEnabled = allChecked  // 모든 항목이 체크되었을 때만 활성화
+        termsView.nextButton.backgroundColor = allChecked ? .accent : .lightGray  // 시각적 피드백
     }
 }
 
@@ -99,7 +109,8 @@ extension TermsModalViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        terms[indexPath.row].2.toggle()
+        terms[indexPath.row].2.toggle()  // 체크 상태 토글
         tableView.reloadRows(at: [indexPath], with: .automatic)
+        updateNextButtonState()  // 상태 변경 후 버튼 업데이트
     }
 }


### PR DESCRIPTION
## 변경사항
- 약관 동의 View 텍스트 수정 
- (선택) 약관 삭제
- 만 14세 이상 약관 토글 제거

## 주요내용
- (필수) 약관 모두 동의를 해야만 다음으로 진행 가능
- 동의 모달 닫은 후 애플 로그인 View로 이동
- 로그인 완료 후 TabBar 이동

## 스크린샷

<img width="400" alt="" src="https://github.com/user-attachments/assets/cd2de3f8-3a07-45fb-be4d-41e9eff3b00f" />
<img width="400" alt="" src="https://github.com/user-attachments/assets/b88ce996-3b19-4d24-b867-74139d5110aa" />


## 추가계획, 고민
- 토글 클릭 시 약관 안내로 이동
-  약관 동의 데이터 메모리 (자동 로그인 구현과 연계 예정)
-  런치 스크린..?

Resolves: #98 