### PR TITLE
Feat : DetailVC 추가기능 구현

### DIFF
--- a/Ting/API/PostService.swift
+++ b/Ting/API/PostService.swift
@@ -84,5 +84,16 @@ class PostService {
             completion(.failure(error))
         }
     }
+    
+    func deletePost(id: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        db.collection("posts").document(id).delete { error in
+            if let error = error {
+                completion(.failure(error))
+            } else {
+                completion(.success(()))
+            }
+        }
+    }
+    
 }
 

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -98,17 +98,20 @@ class PostDetailVC: UIViewController {
     
     private let postType: PostType
     private let post: Post?
+    private let currentUserNickname: String
     
     // MARK: - Initialization
     init(postType: PostType) {
         self.postType = postType
         self.post = nil  // post 프로퍼티 초기화
+        self.currentUserNickname = ""
         super.init(nibName: nil, bundle: nil)
     }
 
-    init(postType: PostType, post: Post) {
+    init(postType: PostType, post: Post, currentUserNickname: String) {
         self.postType = postType
         self.post = post
+        self.currentUserNickname = currentUserNickname
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -288,19 +291,34 @@ class PostDetailVC: UIViewController {
     }
     
     private func setupButton() {
-       reportButton.setTitle("신고하기", for: .normal)
-       reportButton.backgroundColor = .primary
-       reportButton.layer.cornerRadius = 20
-       reportButton.contentEdgeInsets = UIEdgeInsets(top: 8, left: 24, bottom: 8, right: 24)
-       reportButton.titleLabel?.font = .systemFont(ofSize: 16)
+        reportButton.setTitle("신고하기", for: .normal)
+        reportButton.backgroundColor = .primary
+        reportButton.layer.cornerRadius = 20
+        reportButton.contentEdgeInsets = UIEdgeInsets(top: 8, left: 24, bottom: 8, right: 24)
+        reportButton.titleLabel?.font = .systemFont(ofSize: 16)
         reportButton.addTarget(self, action: #selector(reportButtonTapped), for: .touchUpInside)
-       
-       editButton.setTitle("편집하기", for: .normal)
-       editButton.backgroundColor = .accent
-       editButton.layer.cornerRadius = 20
-       editButton.contentEdgeInsets = UIEdgeInsets(top: 8, left: 24, bottom: 8, right: 24)
-       editButton.titleLabel?.font = .systemFont(ofSize: 16)
-       editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
+        
+        editButton.setTitle("편집하기", for: .normal)
+        editButton.backgroundColor = .accent
+        editButton.layer.cornerRadius = 20
+        editButton.contentEdgeInsets = UIEdgeInsets(top: 8, left: 24, bottom: 8, right: 24)
+        editButton.titleLabel?.font = .systemFont(ofSize: 16)
+        editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
+        
+        // 닉네임 비교하여 버튼 표시 여부 결정
+        if let postNickname = post?.nickName {
+            print("Post Nickname:", postNickname)  // 디버그용
+            print("Current User Nickname:", currentUserNickname)  // 디버그용
+            if postNickname == currentUserNickname {
+                // 작성자와 현재 사용자가 같은 경우
+                editButton.isHidden = false
+                reportButton.isHidden = true
+            } else {
+                // 작성자와 현재 사용자가 다른 경우
+                editButton.isHidden = true
+                reportButton.isHidden = false
+            }
+        }
     }
     
     private func addSubviews() {

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -510,7 +510,38 @@ class PostDetailVC: UIViewController {
         }
         
         let deleteAction = UIAlertAction(title: "삭제하기", style: .destructive) { [weak self] _ in
-            // 삭제 로직 구현
+            guard let self = self,
+                  let post = self.post,
+                  let postId = post.id else { return }
+            
+            // 확인 알림창 추가
+            let alert = UIAlertController(title: "삭제 확인",
+                                        message: "정말 삭제하시겠습니까?",
+                                        preferredStyle: .alert)
+            
+            let confirmAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+                PostService.shared.deletePost(id: postId) { result in
+                    switch result {
+                    case .success:
+                        // 삭제 성공 시 이전 화면으로 돌아가기
+                        DispatchQueue.main.async {
+                            self?.navigationController?.popViewController(animated: true)
+                        }
+                    case .failure(let error):
+                        // 실패 시 에러 메시지 표시
+                        DispatchQueue.main.async {
+                            self?.basicAlert(title: "삭제 실패", message: "\(error)")
+                        }
+                    }
+                }
+            }
+            
+            let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+            
+            alert.addAction(confirmAction)
+            alert.addAction(cancelAction)
+            
+            self.present(alert, animated: true)
         }
         
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -293,28 +293,35 @@ class PostDetailVC: UIViewController {
     private func setupButton() {
         reportButton.setTitle("신고하기", for: .normal)
         reportButton.backgroundColor = .primary
-        reportButton.layer.cornerRadius = 20
-        reportButton.contentEdgeInsets = UIEdgeInsets(top: 8, left: 24, bottom: 8, right: 24)
-        reportButton.titleLabel?.font = .systemFont(ofSize: 16)
+        reportButton.layer.cornerRadius = 10  // 변경
+        reportButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)  // 변경
+        reportButton.setTitleColor(.white, for: .normal)
         reportButton.addTarget(self, action: #selector(reportButtonTapped), for: .touchUpInside)
         
         editButton.setTitle("편집하기", for: .normal)
-        editButton.backgroundColor = .accent
-        editButton.layer.cornerRadius = 20
-        editButton.contentEdgeInsets = UIEdgeInsets(top: 8, left: 24, bottom: 8, right: 24)
-        editButton.titleLabel?.font = .systemFont(ofSize: 16)
+        editButton.backgroundColor = .primary
+        editButton.layer.cornerRadius = 10  // 변경
+        editButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)  // 변경
+        editButton.setTitleColor(.white, for: .normal)
         editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
         
+        // 버튼 제약 조건도 수정 필요
+        reportButton.snp.makeConstraints { make in
+            make.height.equalTo(50)  // 변경
+        }
+        
+        editButton.snp.makeConstraints { make in
+            make.height.equalTo(50)  // 변경
+        }
+
         // 닉네임 비교하여 버튼 표시 여부 결정
         if let postNickname = post?.nickName {
-            print("Post Nickname:", postNickname)  // 디버그용
-            print("Current User Nickname:", currentUserNickname)  // 디버그용
+            print("Post Nickname:", postNickname)
+            print("Current User Nickname:", currentUserNickname)
             if postNickname == currentUserNickname {
-                // 작성자와 현재 사용자가 같은 경우
                 editButton.isHidden = false
                 reportButton.isHidden = true
             } else {
-                // 작성자와 현재 사용자가 다른 경우
                 editButton.isHidden = true
                 reportButton.isHidden = false
             }
@@ -428,17 +435,17 @@ class PostDetailVC: UIViewController {
         }
         
         reportButton.snp.makeConstraints { make in
-            make.top.equalTo(descriptionTextView.snp.bottom).offset(16)
-            make.right.equalTo(view.snp.centerX).offset(-8)
+            make.top.equalTo(descriptionTextView.snp.bottom).offset(30)  // 간격 수정
+            make.leading.trailing.equalToSuperview().inset(40)  // 간격 수정
             make.bottom.equalToSuperview().inset(20)
-            make.height.equalTo(40)
+            make.height.equalTo(50)
         }
-        
+
         editButton.snp.makeConstraints { make in
-            make.top.equalTo(descriptionTextView.snp.bottom).offset(16)
-            make.left.equalTo(view.snp.centerX).offset(8)
+            make.top.equalTo(descriptionTextView.snp.bottom).offset(30)  // 간격 수정
+            make.leading.trailing.equalToSuperview().inset(40)  // 간격 수정
             make.bottom.equalToSuperview().inset(20)
-            make.height.equalTo(40)
+            make.height.equalTo(50)
         }
     }
     

--- a/Ting/Post/PostView/PostListVC.swift
+++ b/Ting/Post/PostView/PostListVC.swift
@@ -184,7 +184,8 @@ extension PostListVC: UICollectionViewDelegate {
         let post = postList[indexPath.row]
         /// post 모델의 postType(문자열) 으로 enum PostType 타입으로 복구
         guard let postType = PostType(rawValue: postList[indexPath.row].postType) else { return }
-        let postDetailVC = PostDetailVC(postType: postType, post: post)
+        // currentUserNickname은 로그인된 사용자의 닉네임
+        let postDetailVC = PostDetailVC(postType: postType, post: post, currentUserNickname: "현재사용자닉네임")
         navigationController?.pushViewController(postDetailVC, animated: true)
     }
     


### PR DESCRIPTION
## 변경사항
- Nickname값에 따른 버튼출력 뷰 수정
- 닉네임 값에 따라서 버튼출력
- Delete 기능 구현

## 주요내용
- DetailVC에서 Nickname값 대조해서 작성자와 보는사람의 닉네임이 동일하면 편집하기버튼이, 불일치하면 신고하기 버튼 기능 구현
- 기존에는 신고하기, 편집하기 버튼이 같이 떴지만 이제 하나의 버튼만 출력, 또한 UploadVC의 디자인처럼 적용
- 삭제하기 버튼 터치시 정말 삭제할거냐는 alert뜬 다음에 확인 버튼 누를시 실제 데이터 삭제 기능 적용


## 스크린샷


## 추가계획, 고민
- Nickname 구별값이 없어서 해당기능 구현
- 이후 닉네임 하드코딩된거 전체 수정작업 필요

Resolves: #103 