### PR TITLE
Feat: 루트 뷰 컨트롤러 조정 및 구현

### DIFF
--- a/Ting/AppDelegate.swift
+++ b/Ting/AppDelegate.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 import FirebaseCore
-import FirebaseAuth
-import FirebaseFirestore
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -16,53 +14,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        FirebaseApp.configure()  // Firebase 초기화
-
-        window = UIWindow(frame: UIScreen.main.bounds)
-        
-        // 약관 동의 및 로그인 상태 확인
-        checkAgreementAndLoginStatus { isAgreedAndLoggedIn in
-            if isAgreedAndLoggedIn {
-                // 약관 동의 및 로그인 완료 -> TabBar로 이동
-                let tabBarVC = TabBar()
-                self.window?.rootViewController = tabBarVC
-            } else {
-                // 약관 동의 또는 로그인 필요 -> SignUpViewController로 이동
-                let signUpVC = SignUpViewController()
-                self.window?.rootViewController = signUpVC
-            }
-            self.window?.makeKeyAndVisible()
-        }
-
+        // Firebase 초기화만 담당
+        FirebaseApp.configure()
         return true
     }
-
-    // MARK: - 약관 동의 및 로그인 상태 확인
-    private func checkAgreementAndLoginStatus(completion: @escaping (Bool) -> Void) {
-        guard let userID = Auth.auth().currentUser?.uid else {
-            completion(false)  // 로그인된 유저가 없으면 약관 동의 창으로 이동
-            return
-        }
-
-        let db = Firestore.firestore()
-        db.collection("users").document(userID).getDocument { document, error in
-            if let document = document, document.exists {
-                if let termsAccepted = document.data()?["termsAccepted"] as? Bool {
-                    completion(termsAccepted)  // 약관 동의 여부에 따라 분기
-                } else {
-                    completion(false)  // 약관 동의 기록이 없으면 창을 띄움
-                }
-            } else {
-                completion(false)  // 문서가 존재하지 않음
-            }
-        }
-    }
-
-    // MARK: UISceneSession Lifecycle
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-    }
-
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}
 }
-

--- a/Ting/AppDelegate.swift
+++ b/Ting/AppDelegate.swift
@@ -7,31 +7,62 @@
 
 import UIKit
 import FirebaseCore
+import FirebaseAuth
+import FirebaseFirestore
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
+    var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        FirebaseApp.configure()
+        FirebaseApp.configure()  // Firebase 초기화
+
+        window = UIWindow(frame: UIScreen.main.bounds)
+        
+        // 약관 동의 및 로그인 상태 확인
+        checkAgreementAndLoginStatus { isAgreedAndLoggedIn in
+            if isAgreedAndLoggedIn {
+                // 약관 동의 및 로그인 완료 -> TabBar로 이동
+                let tabBarVC = TabBar()
+                self.window?.rootViewController = tabBarVC
+            } else {
+                // 약관 동의 또는 로그인 필요 -> SignUpViewController로 이동
+                let signUpVC = SignUpViewController()
+                self.window?.rootViewController = signUpVC
+            }
+            self.window?.makeKeyAndVisible()
+        }
+
         return true
     }
 
-    // MARK: UISceneSession Lifecycle
+    // MARK: - 약관 동의 및 로그인 상태 확인
+    private func checkAgreementAndLoginStatus(completion: @escaping (Bool) -> Void) {
+        guard let userID = Auth.auth().currentUser?.uid else {
+            completion(false)  // 로그인된 유저가 없으면 약관 동의 창으로 이동
+            return
+        }
 
+        let db = Firestore.firestore()
+        db.collection("users").document(userID).getDocument { document, error in
+            if let document = document, document.exists {
+                if let termsAccepted = document.data()?["termsAccepted"] as? Bool {
+                    completion(termsAccepted)  // 약관 동의 여부에 따라 분기
+                } else {
+                    completion(false)  // 약관 동의 기록이 없으면 창을 띄움
+                }
+            } else {
+                completion(false)  // 문서가 존재하지 않음
+            }
+        }
+    }
+
+    // MARK: UISceneSession Lifecycle
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
-
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}
 }
 

--- a/Ting/SignUp/SignUpView/SignUpViewController.swift
+++ b/Ting/SignUp/SignUpView/SignUpViewController.swift
@@ -71,10 +71,10 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
                     // Firestore에 약관 동의 상태 저장
                     self.saveAgreementStatus(userID: user.uid)
                     
-                    // TabBar로 완전히 전환 (루트 뷰 컨트롤러 변경)
-                    let tabBarController = TabBar()
-                    let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
-                    sceneDelegate?.window?.rootViewController = tabBarController
+                    // AddInfoVC로 이동
+                    let addInfoVC = AddInfoVC()
+                    addInfoVC.modalPresentationStyle = .fullScreen
+                    self.present(addInfoVC, animated: true)
                 }
             }
         }

--- a/Ting/SignUp/SignUpView/SignUpViewController.swift
+++ b/Ting/SignUp/SignUpView/SignUpViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import AuthenticationServices
 import FirebaseAuth
+import FirebaseFirestore
 import CryptoKit
 
 /// 회원가입 화면의 컨트롤러
@@ -67,16 +68,34 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
                     print("유저 UID: \(user.uid)")
                     print("이메일: \(user.email ?? "이메일 없음")")
                     
+                    // Firestore에 약관 동의 상태 저장
+                    self.saveAgreementStatus(userID: user.uid)
+                    
                     // TabBar로 완전히 전환 (루트 뷰 컨트롤러 변경)
                     let tabBarController = TabBar()
                     let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
-                    sceneDelegate?.window?.rootViewController = tabBarController                }
+                    sceneDelegate?.window?.rootViewController = tabBarController
+                }
             }
         }
     }
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         print("Apple 로그인 실패: \(error.localizedDescription)")
+    }
+}
+
+// MARK: - Firestore에 약관 동의 상태 저장
+extension SignUpViewController {
+    func saveAgreementStatus(userID: String) {
+        let db = Firestore.firestore()
+        db.collection("users").document(userID).setData(["termsAccepted": true]) { error in
+            if let error = error {
+                print("약관 동의 상태 저장 실패: \(error.localizedDescription)")
+            } else {
+                print("약관 동의 상태 저장 성공!")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 변경사항
- AppDelegate에서 SceneDelegate로 앱 화면 별 루트 뷰 컨트롤러 이동.
- 애플 로그인 완료 후 AddInfoVC로 이동

## 주요내용
- 첫 사용자 : 앱 실행 시 회원가입을 위한 약관 동의 뷰 진입 » 동의 후 애플 로그인 뷰 진입 » 로그인 완료 후 AddInfoVC로 이동
- 가입 완료 유저 : 앱 실행 시 바로 TabBar로 이동

## 스크린샷
.

## 추가계획, 고민
- AppDelegate, SceneDelegate를 수정했기 때문에 개인 작업을 하시기 위해서, 주석 처리 후 루트 뷰 컨트롤 변경이 필요합니다.
- 약관 작성..

Resolves: #100 
Resolves: #105 