### PR TITLE
Feat: 회원 탈퇴시 데이터 삭제 구현

### DIFF
--- a/Ting/SignUp/SignUpView/SignUpViewController.swift
+++ b/Ting/SignUp/SignUpView/SignUpViewController.swift
@@ -71,8 +71,8 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
                     // Firestore에 약관 동의 상태 저장
                     self.saveAgreementStatus(userID: user.uid)
                     
-                    // AddInfoVC로 이동
-                    let addInfoVC = AddInfoVC()
+                    // AddUserInfoVC로 이동
+                    let addInfoVC = AddUserInfoVC()
                     addInfoVC.modalPresentationStyle = .fullScreen
                     self.present(addInfoVC, animated: true)
                 }


### PR DESCRIPTION
## 변경사항
- 회원 탈퇴 미동의시 탈퇴하기 버튼 비활성화
- AddInfoVC를 AddUserInfoVC로 이동 및 이름 변경

## 주요내용
- 회원 탈퇴 버튼을 누르면 첫 화면 PermissonVC로 이동
- 동시에 Firebase, Firestore에 저장돼있는 데이터 삭제

## 스크린샷
.

## 추가계획, 고민
- 회원 탈퇴 약관 작성 필요(?)
- 약관 작성

Resolves: #109 