### PR TITLE
Feat : SignUpViewController 새로운 고유구별값 적용 및 회원가입, 정보기입시 적용

### DIFF
--- a/Ting/Models/UserInfo.swift
+++ b/Ting/Models/UserInfo.swift
@@ -12,6 +12,7 @@ struct UserInfo: Identifiable, Codable {
     // 공통 필드 (필수)
     @DocumentID var id: String? // Firestore 문서 ID (자동 생성)
     
+    let userId: String // Firebase user.uid 저장
     let nickName: String  // User 모델 생성 시 User 타입으로 변경 or userID로 변경
     let role: String
     let techStack: String
@@ -20,3 +21,4 @@ struct UserInfo: Identifiable, Codable {
     let location: String
     let interest: String
 }
+

--- a/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
+++ b/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
@@ -14,6 +14,16 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
     // MARK: - UI Components
     private let scrollView = UIScrollView()
     private let contentView = UIView()
+    private let userId: String
+    
+    init(userId: String) {
+        self.userId = userId
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     private let titleLabel = UILabel().then {
         $0.text = "회원정보 추가"
@@ -138,6 +148,7 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
     private func saveBtnTapped() {
         // userInfo 객체 생성
         let userInfo = UserInfo(
+            userId: userId,
             nickName: nameField.textField.text ?? "",
             role: roleField.textField.text ?? "",
             techStack: techStackField.textField.text ?? "",

--- a/Ting/SceneDelegate.swift
+++ b/Ting/SceneDelegate.swift
@@ -20,35 +20,34 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     private func checkCurrentUser() {
         if let currentUser = Auth.auth().currentUser {
-            checkAgreementStatus(userID: currentUser.uid) { isAgreed in
-                DispatchQueue.main.async {
-                    if isAgreed {
-                        self.window?.rootViewController = TabBar()
-                    } else {
-                        let signUpVC = SignUpViewController()
-                        let navController = UINavigationController(rootViewController: signUpVC)
-                        self.window?.rootViewController = navController
-                    }
-                }
-            }
+            checkUserDocument(userID: currentUser.uid)
         } else {
             let signUpVC = SignUpViewController()
             let navController = UINavigationController(rootViewController: signUpVC)
             window?.rootViewController = navController
+            window?.makeKeyAndVisible()
         }
     }
-  private func checkAgreementStatus(userID: String, completion: @escaping (Bool) -> Void) {
-    let db = Firestore.firestore()
-    db.collection("users").document(userID).getDocument { document, error in
-      if let document = document, document.exists {
-        if let termsAccepted = document.data()?["termsAccepted"] as? Bool {
-          completion(termsAccepted)
-        } else {
-          completion(false)
+    
+    private func checkUserDocument(userID: String) {
+        let db = Firestore.firestore()
+        db.collection("users").document(userID).getDocument { [weak self] document, _ in
+            if let document = document, document.exists {
+                // 기존 사용자는 TabBar나 PermissionVC로
+                if let termsAccepted = document.data()?["termsAccepted"] as? Bool, termsAccepted {
+                    self?.window?.rootViewController = TabBar()
+                } else {
+                    let signUpVC = SignUpViewController()
+                    let navController = UINavigationController(rootViewController: signUpVC)
+                    self?.window?.rootViewController = navController
+                }
+            } else {
+                // 사용자 문서가 없으면 SignUpViewController로
+                let signUpVC = SignUpViewController()
+                let navController = UINavigationController(rootViewController: signUpVC)
+                self?.window?.rootViewController = navController
+            }
+            self?.window?.makeKeyAndVisible()
         }
-      } else {
-        completion(false)
-      }
     }
-  }
 }

--- a/Ting/SceneDelegate.swift
+++ b/Ting/SceneDelegate.swift
@@ -8,48 +8,47 @@
 import UIKit
 import FirebaseAuth
 import FirebaseFirestore
-
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
     var window: UIWindow?
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        
         window = UIWindow(windowScene: windowScene)
-
-        // 로그인 및 약관 동의 상태 확인
+        // 주석 처리된 코드를 활성화하고 테스트 코드 제거
+        checkCurrentUser()
+        window?.makeKeyAndVisible()
+    }
+    
+    private func checkCurrentUser() {
         if let currentUser = Auth.auth().currentUser {
             checkAgreementStatus(userID: currentUser.uid) { isAgreed in
-                if isAgreed {
-                    // 약관 동의 및 로그인 완료된 사용자 → TabBar로 이동
-                    self.window?.rootViewController = TabBar()
-                } else {
-                    // 로그인했지만 약관 동의가 되지 않은 사용자 → PermissionVC로 이동
-                    self.window?.rootViewController = PermissionVC()
+                DispatchQueue.main.async {
+                    if isAgreed {
+                        self.window?.rootViewController = TabBar()
+                    } else {
+                        let signUpVC = SignUpViewController()
+                        let navController = UINavigationController(rootViewController: signUpVC)
+                        self.window?.rootViewController = navController
+                    }
                 }
-                self.window?.makeKeyAndVisible()
             }
         } else {
-            // 로그인되지 않은 사용자 → PermissionVC로 이동
-            self.window?.rootViewController = PermissionVC()
-            self.window?.makeKeyAndVisible()
+            let signUpVC = SignUpViewController()
+            let navController = UINavigationController(rootViewController: signUpVC)
+            window?.rootViewController = navController
         }
     }
-
-    private func checkAgreementStatus(userID: String, completion: @escaping (Bool) -> Void) {
-        let db = Firestore.firestore()
-        db.collection("users").document(userID).getDocument { document, error in
-            if let document = document, document.exists {
-                if let termsAccepted = document.data()?["termsAccepted"] as? Bool {
-                    completion(termsAccepted)
-                } else {
-                    completion(false)
-                }
-            } else {
-                completion(false)
-            }
+  private func checkAgreementStatus(userID: String, completion: @escaping (Bool) -> Void) {
+    let db = Firestore.firestore()
+    db.collection("users").document(userID).getDocument { document, error in
+      if let document = document, document.exists {
+        if let termsAccepted = document.data()?["termsAccepted"] as? Bool {
+          completion(termsAccepted)
+        } else {
+          completion(false)
         }
+      } else {
+        completion(false)
+      }
     }
+  }
 }
-

--- a/Ting/SignUp/SignUpView/SignUpViewController.swift
+++ b/Ting/SignUp/SignUpView/SignUpViewController.swift
@@ -78,22 +78,23 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
 
 // MARK: - Firestore에 약관 동의 상태 저장
 extension SignUpViewController {
-    func createUserDocument(for user: User) {
-        let db = Firestore.firestore()
-        let userData: [String: Any] = [
-            "id": user.uid,
-            "email": user.email ?? "",
-            "createdAt": Timestamp()
-        ]
-        
-        db.collection("users").document(user.uid).setData(userData) { error in
-            if let error = error {
-                print("사용자 문서 생성 실패: \(error)")
-            } else {
-                print("사용자 문서 생성 성공")
-            }
-        }
-    }
+   func createUserDocument(for user: User) {
+       let db = Firestore.firestore()
+       let userData: [String: Any] = [
+           "id": user.uid,              // 고유 키값
+           "email": user.email ?? "",   // 애플id 이메일값
+           "createdAt": Timestamp(),    // 생성날짜
+           "termsAccepted": true        // 약관 동의
+       ]
+       
+       db.collection("users").document(user.uid).setData(userData) { error in
+           if let error = error {
+               print("사용자 문서 생성 실패: \(error)")
+           } else {
+               print("사용자 문서 생성 성공")
+           }
+       }
+   }
 }
 
 // MARK: - Nonce 생성 및 해싱

--- a/Ting/SignUp/SignUpView/SignUpViewController.swift
+++ b/Ting/SignUp/SignUpView/SignUpViewController.swift
@@ -30,12 +30,12 @@ class SignUpViewController: UIViewController {
     }
     
     @objc private func handleAppleLogin() {
-        rawNonce = Self.randomNonceString()
-        let hashedNonce = Self.sha256(rawNonce!)
+        rawNonce = Self.randomNonceString() 
+        let hashedNonce = Self.sha256(rawNonce!) // 해싱된 nonce 생성
         
         let request = ASAuthorizationAppleIDProvider().createRequest()
         request.requestedScopes = [.fullName, .email]
-        request.nonce = hashedNonce
+        request.nonce = hashedNonce // 애플 요청에 해시된 nonce 포함
         
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
@@ -48,7 +48,7 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
            let identityToken = appleIDCredential.identityToken,
            let tokenString = String(data: identityToken, encoding: .utf8),
-           let rawNonce = rawNonce {
+           let rawNonce = rawNonce {  // 저장된 rawNonce 사용
             
             // Firebase 인증
             let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: tokenString, rawNonce: rawNonce)


### PR DESCRIPTION
## 구현 기능
- SignUpViewController에서 새로운 유저 확인용 고유키값 id 생성 및 저장
- 이후 AddUserInfoVC에서 해당 값이 넘어가 userID라는 값으로 저장이됨
- Nickname을 고유 키값으로 사용하기 위한 닉네임 중복검증 필요
- 기능 구현을 위한 SceneDelegate 수정

## 변경사항
- SignUpViewController 파일 수정
- AddUserInfoVC 파일 수정
- UserInfo 파일 수정
- 로그인 상태값에 따라 로그인이 안된상태는 SignUpViewController로, 로그인이 된 상태는 메인으로 넘어가게  SceneDelegate 로직 수정

## 주요내용
- SignUpViewController 애플 로그인 시 회원고유 키값 생성
- 생성된 고유 키값은 AddUserInfoVC로 넘어갈때 같이 넘어가져서 해당 컬렉션에 값이 값 저장
- 생성된 고유 키값을 생성, 사용하기 위한UserInfo 파일 수정


## 추가계획, 고민
- Nickname을 고유 키값으로 사용하기 위한 닉네임 중복검증 필요
- 현재는 회원가입으로만 테스트를 했는데 신규 기기로 로그인시, 혹은 로그아웃 된 상태에서 신규 생성이 되는지 안되는지 테스트 필요


Resolves: #110 