### PR TITLE
Feat : 각 뷰간 nickname 데이터 객체 이동 / 수정시 바로 업데이트 기능 구현 / detailVC 불필요 라벨 제거

### DIFF
--- a/Ting/API/PostService.swift
+++ b/Ting/API/PostService.swift
@@ -181,4 +181,24 @@ class PostService {
         
         return Array(keywords)
     }
+    
+    func getPost(id: String, completion: @escaping (Result<Post?, Error>) -> Void) {
+        db.collection("posts").document(id).getDocument { snapshot, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            
+            do {
+                if let document = snapshot {
+                    let post = try document.data(as: Post.self)
+                    completion(.success(post))
+                } else {
+                    completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Document does not exist"])))
+                }
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
 }

--- a/Ting/Post/PostView/JoinTeamUploadVC.swift
+++ b/Ting/Post/PostView/JoinTeamUploadVC.swift
@@ -50,6 +50,8 @@ final class JoinTeamUploadVC: UIViewController {
     }
     
     @objc private func submitButtonTapped() {
+        print("➡️ JoinTeamUploadVC - submitButtonTapped() called")
+        
         // 버튼 및 텍스트 입력 검사
         guard !selectedPositions.isEmpty,
               !selectedAvailable.isEmpty,
@@ -57,69 +59,95 @@ final class JoinTeamUploadVC: UIViewController {
               !selectedTeamSize.isEmpty,
               !selectedMeetingStyle.isEmpty,
               !selectedCurrentStatus.isEmpty,
-              // 텍스트 필드 입력 확인
               let techInput = uploadView.techStackTextField.textField.text,
               !techInput.isEmpty,
               let titleInput = uploadView.titleSection.textField.text,
               !titleInput.isEmpty,
               let detailInput = uploadView.detailTextView.text,
               !detailInput.isEmpty else {
+            print("❌ JoinTeamUploadVC - 필수 입력값 누락")
             basicAlert(title: "입력 필요", message: "빈칸을 채워주세요")
             return
         }
         
-        let techArray = techInput.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
-        let keywords = PostService.shared.generateSearchKeywords(from: titleInput)
-        // Post 생성 및 업로드
-        let post = Post(
-            id: nil,
-            nickName: "test",
-            postType: postType.rawValue,
-            title: titleInput,
-            detail: detailInput,
-            position: selectedPositions,
-            techStack: techArray,
-            ideaStatus: selectedIdeaStatus,
-            meetingStyle: selectedMeetingStyle,
-            numberOfRecruits: selectedTeamSize,
-            createdAt: Date(),
-            urgency: nil,
-            experience: nil,
-            available: selectedAvailable,
-            currentStatus: selectedCurrentStatus,
-            tags: [postType.rawValue, selectedMeetingStyle] + selectedPositions,
-            searchKeywords: keywords
-        )
-        
-        if isEditMode {
-            // 수정 모드일 경우 update 호출
-            guard let postId = editPostId else { return }
-            PostService.shared.updatePost(id: postId, post: post) { [weak self] result in
-                switch result {
-                case .success:
-                    // 글 작성 후 데이터 새로 고침
-                    if let navigationController = self?.navigationController,
-                       let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) as? PostListVC {
-                        postListVC.loadInitialData()
-                    }
-                    self?.navigationController?.popViewController(animated: true)
-                case .failure(let error):
-                    self?.basicAlert(title: "수정 실패", message: "\(error.localizedDescription)")
-                }
-            }
+        // UserDefaults에서 userId 확인
+        if let userId = UserDefaults.standard.string(forKey: "userId") {
+            print("✅ JoinTeamUploadVC - UserDefaults에서 불러온 userId: \(userId)")
         } else {
-            // 신규 작성일 경우 기존 코드대로 upload 호출
-            PostService.shared.uploadPost(post: post) { [weak self] result in
-                switch result {
-                case .success:
-                    // 글 작성 후 데이터 새로 고침
-                    if let navigationController = self?.navigationController,
-                       let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) as? PostListVC {
-                        postListVC.loadInitialData()
+            print("❌ JoinTeamUploadVC - UserDefaults에 userId 없음")
+        }
+        
+        // 사용자 정보 가져오기
+        UserInfoService.shared.fetchUserInfo { [weak self] result in
+            guard let self = self else { return }
+            
+            switch result {
+            case .success(let userInfo):
+                print("✅ JoinTeamUploadVC - 사용자 정보 조회 성공")
+                print("✅ JoinTeamUploadVC - 닉네임: \(userInfo.nickName)")
+                
+                let techArray = techInput.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+                let keywords = PostService.shared.generateSearchKeywords(from: titleInput)
+                
+                let post = Post(
+                    id: nil,
+                    nickName: userInfo.nickName,
+                    postType: postType.rawValue,
+                    title: titleInput,
+                    detail: detailInput,
+                    position: selectedPositions,
+                    techStack: techArray,
+                    ideaStatus: selectedIdeaStatus,
+                    meetingStyle: selectedMeetingStyle,
+                    numberOfRecruits: selectedTeamSize,
+                    createdAt: Date(),
+                    urgency: nil,
+                    experience: nil,
+                    available: selectedAvailable,
+                    currentStatus: selectedCurrentStatus,
+                    tags: [postType.rawValue, selectedMeetingStyle] + selectedPositions,
+                    searchKeywords: keywords
+                )
+                
+                print("✅ JoinTeamUploadVC - 생성된 Post 객체의 닉네임: \(post.nickName)")
+                
+                if isEditMode {
+                    guard let postId = editPostId else { return }
+                    PostService.shared.updatePost(id: postId, post: post) { [weak self] result in
+                        switch result {
+                        case .success:
+                            print("✅ JoinTeamUploadVC - 게시글 수정 성공")
+                            if let navigationController = self?.navigationController,
+                               let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) as? PostListVC {
+                                postListVC.loadInitialData()
+                            }
+                            self?.navigationController?.popViewController(animated: true)
+                        case .failure(let error):
+                            print("❌ JoinTeamUploadVC - 게시글 수정 실패: \(error.localizedDescription)")
+                            self?.basicAlert(title: "수정 실패", message: "\(error.localizedDescription)")
+                        }
                     }
-                    self?.navigationController?.popViewController(animated: true)
-                case .failure(let error):
-                    self?.basicAlert(title: "업로드 실패", message: "\(error.localizedDescription)")
+                } else {
+                    PostService.shared.uploadPost(post: post) { [weak self] result in
+                        switch result {
+                        case .success:
+                            print("✅ JoinTeamUploadVC - 게시글 업로드 성공")
+                            if let navigationController = self?.navigationController,
+                               let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) as? PostListVC {
+                                postListVC.loadInitialData()
+                            }
+                            self?.navigationController?.popViewController(animated: true)
+                        case .failure(let error):
+                            print("❌ JoinTeamUploadVC - 게시글 업로드 실패: \(error.localizedDescription)")
+                            self?.basicAlert(title: "업로드 실패", message: "\(error.localizedDescription)")
+                        }
+                    }
+                }
+                
+            case .failure(let error):
+                print("❌ JoinTeamUploadVC - 사용자 정보 조회 실패: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    self.basicAlert(title: "사용자 정보 조회 실패", message: error.localizedDescription)
                 }
             }
         }

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -87,10 +87,6 @@ class PostDetailVC: UIViewController {
     private let titleLabel = UILabel()
     private let statusTagsView = TagFlowLayout()
     private let activityTimeLabel = UILabel()
-    private let availableTimeLabel = UILabel()
-    private let availableTimeValueLabel = UILabel()
-    private let timeStateLabel = UILabel()
-    private let timeStateValueLabel = UILabel()
     private let urgencyLabel = UILabel()
     private let urgencyValueLabel = UILabel()
     private let techStackLabel = UILabel()
@@ -195,24 +191,6 @@ class PostDetailVC: UIViewController {
         activityTimeLabel.text = "활동 가능 상태"
         activityTimeLabel.font = .systemFont(ofSize: 18, weight: .medium)
         activityTimeLabel.textColor = .deepCocoa
-            
-        availableTimeLabel.text = "가능한 기간"
-        availableTimeLabel.font = .systemFont(ofSize: 16)
-        availableTimeLabel.textColor = .brownText
-            
-        availableTimeValueLabel.text = post.available ?? "정보 없음"
-        availableTimeValueLabel.font = .systemFont(ofSize: 16)
-        availableTimeValueLabel.textColor = .deepCocoa
-        availableTimeValueLabel.textAlignment = .right
-            
-        timeStateLabel.text = "가능한 시간"
-        timeStateLabel.font = .systemFont(ofSize: 16)
-        timeStateLabel.textColor = .brownText
-            
-        timeStateValueLabel.text = post.currentStatus ?? "정보 없음"
-        timeStateValueLabel.font = .systemFont(ofSize: 16)
-        timeStateValueLabel.textColor = .deepCocoa
-        timeStateValueLabel.textAlignment = .right
             
         urgencyLabel.text = "시급성"
         urgencyLabel.font = .systemFont(ofSize: 16)
@@ -369,8 +347,6 @@ class PostDetailVC: UIViewController {
         
         whiteCardView.addSubviews([
             titleLabel, statusTagsView, activityTimeLabel,
-            availableTimeLabel, availableTimeValueLabel,
-            timeStateLabel, timeStateValueLabel,
             urgencyLabel, urgencyValueLabel,
             techStackLabel, techStacksView,
             projectTypeLabel, projectTypeView,
@@ -407,28 +383,8 @@ class PostDetailVC: UIViewController {
             make.left.right.equalToSuperview().inset(20)
         }
         
-        availableTimeLabel.snp.makeConstraints { make in
-            make.top.equalTo(activityTimeLabel.snp.bottom).offset(16)
-            make.left.equalToSuperview().inset(20)
-        }
-        
-        availableTimeValueLabel.snp.makeConstraints { make in
-            make.centerY.equalTo(availableTimeLabel)
-            make.right.equalToSuperview().inset(20)
-        }
-        
-        timeStateLabel.snp.makeConstraints { make in
-            make.top.equalTo(availableTimeLabel.snp.bottom).offset(12)
-            make.left.equalToSuperview().inset(20)
-        }
-        
-        timeStateValueLabel.snp.makeConstraints { make in
-            make.centerY.equalTo(timeStateLabel)
-            make.right.equalToSuperview().inset(20)
-        }
-        
         urgencyLabel.snp.makeConstraints { make in
-            make.top.equalTo(timeStateLabel.snp.bottom).offset(12)
+            make.top.equalTo(activityTimeLabel.snp.bottom).offset(12)
             make.left.equalToSuperview().inset(20)
         }
         

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -450,22 +450,11 @@ class PostDetailVC: UIViewController {
     }
     
     @objc private func reportButtonTapped() {
-        let post = Post(
-            nickName: "작성자닉네임",
-            postType: postType == .recruitMember ? "팀원구함" : "팀 구함",  // rawValue 대신 직접 문자열 지정
-            title: titleLabel.text ?? "",
-            detail: descriptionTextView.text,
-            position: [],
-            techStack: [],
-            ideaStatus: "",
-            meetingStyle: "",
-            numberOfRecruits: "",
-            createdAt: Date(),
-            tags: [],
-            searchKeywords: []
-        )
+        guard let post = post else { return }
         
-        let reportVC = ReportVC(post: post, reporterNickname: "신고자닉네임")
+        print("✅ PostDetailVC - 신고하기: 작성자 닉네임 \(post.nickName)")
+        
+        let reportVC = ReportVC(post: post, reporterNickname: currentUserNickname)
         navigationController?.pushViewController(reportVC, animated: true)
     }
     

--- a/Ting/Post/PostView/RecruitMemberUploadVC.swift
+++ b/Ting/Post/PostView/RecruitMemberUploadVC.swift
@@ -55,6 +55,8 @@ final class RecruitMemberUploadVC: UIViewController {
     }
     
     @objc private func submitButtonTapped() {
+        print("➡️ RecruitMemberUploadVC - submitButtonTapped() called")
+        
         // 버튼 및 텍스트 입력 검사
         guard !selectedPositions.isEmpty,
               !selectedUrgency.isEmpty,
@@ -62,70 +64,95 @@ final class RecruitMemberUploadVC: UIViewController {
               !selectedRecruits.isEmpty,
               !selectedMeetingStyle.isEmpty,
               !selectedExperience.isEmpty,
-              // 텍스트 필드 입력 확인
               let techInput = uploadView.techStackTextField.textField.text,
               !techInput.isEmpty,
               let titleInput = uploadView.titleSection.textField.text,
               !titleInput.isEmpty,
               let detailInput = uploadView.detailTextView.text,
               !detailInput.isEmpty else {
+            print("❌ RecruitMemberUploadVC - 필수 입력값 누락")
             basicAlert(title: "입력 필요", message: "빈칸을 채워주세요")
             return
         }
-        // 기술스택 : , 공백 제거 후 배열로 반환
-        let techArray = techInput.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
-        // 검색용 키워드배열 생성
-        let keywords = PostService.shared.generateSearchKeywords(from: titleInput)
-        // Post 생성 및 업로드
-        let post = Post(
-            id: nil,
-            nickName: "test",
-            postType: postType.rawValue,
-            title: titleInput,
-            detail: detailInput,
-            position: selectedPositions,
-            techStack: techArray,
-            ideaStatus: selectedIdeaStatus,
-            meetingStyle: selectedMeetingStyle,
-            numberOfRecruits: selectedRecruits,
-            createdAt: Date(),
-            urgency: selectedUrgency,
-            experience: selectedExperience,
-            available: nil,
-            currentStatus: nil,
-            tags: [postType.rawValue, selectedMeetingStyle] + selectedPositions,
-            searchKeywords: keywords
-        )
         
-        if isEditMode {
-            // 수정 모드일 경우 update 호출
-            guard let postId = editPostId else { return }
-            PostService.shared.updatePost(id: postId, post: post) { [weak self] result in
-                switch result {
-                case .success:
-                    // 글 작성 후 데이터 새로 고침
-                    if let navigationController = self?.navigationController,
-                       let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) as? PostListVC {
-                        postListVC.loadInitialData()
-                    }
-                    self?.navigationController?.popViewController(animated: true)
-                case .failure(let error):
-                    self?.basicAlert(title: "수정 실패", message: "\(error.localizedDescription)")
-                }
-            }
+        // UserDefaults에서 userId 확인
+        if let userId = UserDefaults.standard.string(forKey: "userId") {
+            print("✅ RecruitMemberUploadVC - UserDefaults에서 불러온 userId: \(userId)")
         } else {
-            // 신규 작성일 경우 기존 코드대로 upload 호출
-            PostService.shared.uploadPost(post: post) { [weak self] result in
-                switch result {
-                case .success:
-                    // 글 작성 후 데이터 새로 고침
-                    if let navigationController = self?.navigationController,
-                       let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) as? PostListVC {
-                        postListVC.loadInitialData()
+            print("❌ RecruitMemberUploadVC - UserDefaults에 userId 없음")
+        }
+        
+        // 사용자 정보 가져오기
+        UserInfoService.shared.fetchUserInfo { [weak self] result in
+            guard let self = self else { return }
+            
+            switch result {
+            case .success(let userInfo):
+                print("✅ RecruitMemberUploadVC - 사용자 정보 조회 성공")
+                print("✅ RecruitMemberUploadVC - 닉네임: \(userInfo.nickName)")
+                
+                let techArray = techInput.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+                let keywords = PostService.shared.generateSearchKeywords(from: titleInput)
+                
+                let post = Post(
+                    id: nil,
+                    nickName: userInfo.nickName,
+                    postType: postType.rawValue,
+                    title: titleInput,
+                    detail: detailInput,
+                    position: selectedPositions,
+                    techStack: techArray,
+                    ideaStatus: selectedIdeaStatus,
+                    meetingStyle: selectedMeetingStyle,
+                    numberOfRecruits: selectedRecruits,
+                    createdAt: Date(),
+                    urgency: selectedUrgency,
+                    experience: selectedExperience,
+                    available: nil,
+                    currentStatus: nil,
+                    tags: [postType.rawValue, selectedMeetingStyle] + selectedPositions,
+                    searchKeywords: keywords
+                )
+                
+                print("✅ RecruitMemberUploadVC - 생성된 Post 객체의 닉네임: \(post.nickName)")
+                
+                if isEditMode {
+                    guard let postId = editPostId else { return }
+                    PostService.shared.updatePost(id: postId, post: post) { [weak self] result in
+                        switch result {
+                        case .success:
+                            print("✅ RecruitMemberUploadVC - 게시글 수정 성공")
+                            if let navigationController = self?.navigationController,
+                               let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) as? PostListVC {
+                                postListVC.loadInitialData()
+                            }
+                            self?.navigationController?.popViewController(animated: true)
+                        case .failure(let error):
+                            print("❌ RecruitMemberUploadVC - 게시글 수정 실패: \(error.localizedDescription)")
+                            self?.basicAlert(title: "수정 실패", message: "\(error.localizedDescription)")
+                        }
                     }
-                    self?.navigationController?.popViewController(animated: true)
-                case .failure(let error):
-                    self?.basicAlert(title: "업로드 실패", message: "\(error.localizedDescription)")
+                } else {
+                    PostService.shared.uploadPost(post: post) { [weak self] result in
+                        switch result {
+                        case .success:
+                            print("✅ RecruitMemberUploadVC - 게시글 업로드 성공")
+                            if let navigationController = self?.navigationController,
+                               let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) as? PostListVC {
+                                postListVC.loadInitialData()
+                            }
+                            self?.navigationController?.popViewController(animated: true)
+                        case .failure(let error):
+                            print("❌ RecruitMemberUploadVC - 게시글 업로드 실패: \(error.localizedDescription)")
+                            self?.basicAlert(title: "업로드 실패", message: "\(error.localizedDescription)")
+                        }
+                    }
+                }
+                
+            case .failure(let error):
+                print("❌ RecruitMemberUploadVC - 사용자 정보 조회 실패: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    self.basicAlert(title: "사용자 정보 조회 실패", message: error.localizedDescription)
                 }
             }
         }

--- a/Ting/Post/PostView/ReportVC.swift
+++ b/Ting/Post/PostView/ReportVC.swift
@@ -414,7 +414,12 @@ class ReportVC: UIViewController, UITextViewDelegate {
         )
         
         let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
-            self?.dismiss(animated: true)
+            // 현재 navigation stack에서 PostListVC 찾기
+            if let navigationController = self?.navigationController,
+               let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) {
+                // PostListVC로 한번에 이동 (중간 화면들은 스택에서 제거됨)
+                navigationController.popToViewController(postListVC, animated: true)
+            }
         }
         
         alert.addAction(confirmAction)

--- a/Ting/Post/PostView/ReportVC.swift
+++ b/Ting/Post/PostView/ReportVC.swift
@@ -1,475 +1,143 @@
 //
-//  ReportVC.swift
+//  SignUpViewController.swift
 //  Ting
 //
-//  Created by 이재건 on 1/21/25.
+//  Created by Sol on 1/21/25.
 //
 
 import UIKit
-import SnapKit
+import AuthenticationServices
+import FirebaseAuth
 import FirebaseFirestore
+import CryptoKit
 
-class ReportVC: UIViewController, UITextViewDelegate {
-    // MARK: - Properties
-    private var selectedReason: String?
-    private var targetPost: Post?
-    private var reporterNickname: String?
+class SignUpViewController: UIViewController {
     
-    // MARK: - UI Components
-    private let scrollView = UIScrollView()
-    private let contentView = UIView()
-    private let titleLabel = UILabel()
-    private let whiteCardView = UIView()
-    private let targetInfoView = UIView()
-    private let reasonCardView = UIView()
-    private let placeholderText = "신고 사유에 대해 자세히 설명해주세요"
-    private let postTitleLabel = UILabel()
-    private let postTitleValueLabel = UILabel()
-    private let authorLabel = UILabel()
-    private let authorValueLabel = UILabel()
-    private let dateLabelTitle = UILabel()
-    private let dateValueLabel = UILabel()
-    private let reportReasonLabel = UILabel()
-    private let radioStackView = UIStackView()
-    private let spamButton = createRadioButton()
-    private let spamLabel = UILabel()
-    private let harmButton = createRadioButton()
-    private let harmLabel = UILabel()
-    private let abuseButton = createRadioButton()
-    private let abuseLabel = UILabel()
-    private let privacyButton = createRadioButton()
-    private let privacyLabel = UILabel()
-    private let inappropriateButton = createRadioButton()
-    private let inappropriateLabel = UILabel()
-    private let etcButton = createRadioButton()
-    private let etcLabel = UILabel()
-    private let reportDescriptionTextView = UITextView()
-    private let reportButton = UIButton()
+    private let signUpView = SignUpView()
+    private var rawNonce: String?
     
-    // MARK: - Initialization
-    init(post: Post, reporterNickname: String) {
-        self.targetPost = post
-        self.reporterNickname = reporterNickname
-        super.init(nibName: nil, bundle: nil)
+    override func loadView() {
+        view = signUpView
     }
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    // MARK: - Lifecycle Methods
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI()
-        setupInitialData()
+        setupActions()
+        navigationController?.navigationBar.isHidden = true // 네비게이션컨트롤러 가리는 객체
     }
     
-    private func formatDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy/MM/dd"
-        return formatter.string(from: date)
+    
+    
+    private func setupActions() {
+        signUpView.appleLoginButton.addTarget(self, action: #selector(handleAppleLogin), for: .touchUpInside)
     }
     
-    private func setupInitialData() {
-        if let post = targetPost {
-            postTitleValueLabel.text = post.title
-            authorValueLabel.text = post.nickName
-            dateValueLabel.text = formatDate(post.createdAt)
-        }
-    }
-    
-    // MARK: - UI Configuration
-    private func configureUI() {
-        setupBasic()
-        setupComponents()
-        setupConstraints()
-    }
-    
-    private func setupBasic() {
-        view.backgroundColor = .background
-        scrollView.backgroundColor = .clear
-        contentView.backgroundColor = .clear
+    @objc private func handleAppleLogin() {
+        rawNonce = Self.randomNonceString()
+        let hashedNonce = Self.sha256(rawNonce!) // 해싱된 nonce 생성
         
-        targetInfoView.backgroundColor = .white
-        targetInfoView.layer.cornerRadius = 12
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = hashedNonce // 애플 요청에 해시된 nonce 포함
         
-        reasonCardView.backgroundColor = .white
-        reasonCardView.layer.cornerRadius = 12
-        
-        radioStackView.axis = .vertical
-        radioStackView.spacing = 24
-        radioStackView.distribution = .fillEqually
-        radioStackView.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
-        radioStackView.isLayoutMarginsRelativeArrangement = true
-        radioStackView.spacing = 24
-    }
-    
-    private func setupComponents() {
-        setupLabels()
-        setupRadioButtons()
-        setupTextView()
-        setupButton()
-        addSubviews()
-    }
-    
-    private func setupLabels() {
-        titleLabel.text = "신고 대상"
-        titleLabel.font = .systemFont(ofSize: 18, weight: .bold)
-        titleLabel.textColor = .deepCocoa
-        
-        postTitleLabel.text = "게시글 제목"
-        postTitleLabel.font = .systemFont(ofSize: 16)
-        postTitleLabel.textColor = .brownText
-        
-        postTitleValueLabel.text = targetPost?.title ?? "신고할 게시글 제목"
-        postTitleValueLabel.font = .systemFont(ofSize: 16)
-        postTitleValueLabel.textColor = .deepCocoa
-        postTitleValueLabel.textAlignment = .right
-        
-        authorLabel.text = "작성자"
-        authorLabel.font = .systemFont(ofSize: 16)
-        authorLabel.textColor = .brownText
-        
-        authorValueLabel.text = targetPost?.nickName ?? "본인 이름or닉네임"
-        authorValueLabel.font = .systemFont(ofSize: 16)
-        authorValueLabel.textColor = .deepCocoa
-        authorValueLabel.textAlignment = .right
-        
-        dateLabelTitle.text = "작성일"
-        dateLabelTitle.font = .systemFont(ofSize: 16)
-        dateLabelTitle.textColor = .brownText
-        
-        dateValueLabel.text = ReportManager.shared.getCurrentTime()
-        dateValueLabel.font = .systemFont(ofSize: 16)
-        dateValueLabel.textColor = .deepCocoa
-        dateValueLabel.textAlignment = .right
-        
-        reportReasonLabel.text = "신고 사유"
-        reportReasonLabel.font = .systemFont(ofSize: 18, weight: .bold)
-        reportReasonLabel.textColor = .deepCocoa
-        setupReasonLabels()
-    }
-    
-    private func setupReasonLabels() {
-        [spamLabel, harmLabel, abuseLabel, privacyLabel, inappropriateLabel, etcLabel].forEach {
-            $0.font = .systemFont(ofSize: 16)
-            $0.textColor = .deepCocoa
-        }
-        
-        spamLabel.text = "스팸/홍보성 게시글"
-        harmLabel.text = "위험 정보"
-        abuseLabel.text = "욕설/비방"
-        privacyLabel.text = "개인정보 노출"
-        inappropriateLabel.text = "음란성/선정성"
-        etcLabel.text = "기타"
-    }
-    
-    private static func createRadioButton() -> UIButton {
-        let button = UIButton()
-        button.layer.borderWidth = 2
-        button.layer.cornerRadius = 10
-        button.layer.borderColor = UIColor.grayCloud.cgColor
-        button.backgroundColor = .white
-        button.contentMode = .center
-        button.imageView?.contentMode = .scaleAspectFit
-        button.imageEdgeInsets = UIEdgeInsets(top: 2, left: 2, bottom: 2, right: 2)
-        return button
-    }
-    
-    private func setupRadioButtons() {
-       [spamButton, harmButton, abuseButton,
-        privacyButton, inappropriateButton, etcButton].forEach { button in
-           button.addTarget(self, action: #selector(radioButtonTapped(_:)), for: .touchUpInside)
-       }
-    }
-    
-    private func setupTextView() {
-        reportDescriptionTextView.backgroundColor = .white
-        reportDescriptionTextView.layer.cornerRadius = 12
-        reportDescriptionTextView.font = .systemFont(ofSize: 16)
-        reportDescriptionTextView.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-        reportDescriptionTextView.text = placeholderText
-        reportDescriptionTextView.textColor = .grayCloud
-        reportDescriptionTextView.delegate = self
-    }
-    
-    private func setupButton() {
-        reportButton.setTitle("신고하기", for: .normal)
-        reportButton.backgroundColor = .primary
-        reportButton.layer.cornerRadius = 8
-        reportButton.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
-        reportButton.addTarget(self, action: #selector(reportButtonTapped), for: .touchUpInside)
-    }
-    
-    private func addSubviews() {
-        view.addSubview(scrollView)
-        scrollView.addSubview(contentView)
-        
-        [titleLabel, targetInfoView, reportReasonLabel, reasonCardView,
-         reportDescriptionTextView, reportButton].forEach { contentView.addSubview($0) }
-        
-        reasonCardView.addSubview(radioStackView)
-        
-        targetInfoView.addSubviews([
-            postTitleLabel, postTitleValueLabel,
-            authorLabel, authorValueLabel,
-            dateLabelTitle, dateValueLabel
-        ])
-        
-         [(spamButton, spamLabel),
-         (harmButton, harmLabel),
-         (abuseButton, abuseLabel),
-         (privacyButton, privacyLabel),
-         (inappropriateButton, inappropriateLabel),
-         (etcButton, etcLabel)].forEach { button, label in
-            let container = UIView()
-            container.backgroundColor = .clear
-            container.addSubview(button)
-            container.addSubview(label)
-            radioStackView.addArrangedSubview(container)
-             
-             button.snp.makeConstraints { make in
-                 make.centerY.equalToSuperview()
-                 make.left.equalToSuperview()
-                 make.size.equalTo(20)
-             }
-             
-            label.snp.makeConstraints { make in
-                make.centerY.equalToSuperview()
-                make.left.equalTo(button.snp.right).offset(12)
-                make.right.equalToSuperview()
-            }
-        }
-    }
-    
-    private func setupConstraints() {
-        scrollView.snp.makeConstraints { make in
-            make.edges.equalTo(view.safeAreaLayoutGuide)
-        }
-        
-        contentView.snp.makeConstraints { make in
-            make.edges.equalTo(scrollView.contentLayoutGuide)
-            make.width.equalTo(scrollView.frameLayoutGuide)
-        }
-        
-        titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(contentView).offset(20)
-            make.left.right.equalTo(contentView).inset(20)
-        }
-        
-        targetInfoView.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(16)
-            make.left.right.equalTo(contentView).inset(20)
-        }
-        
-        postTitleLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(16)
-            make.left.equalToSuperview().offset(16)
-        }
-        
-        postTitleValueLabel.snp.makeConstraints { make in
-            make.centerY.equalTo(postTitleLabel)
-            make.right.equalToSuperview().offset(-16)
-        }
-        
-        authorLabel.snp.makeConstraints { make in
-            make.top.equalTo(postTitleLabel.snp.bottom).offset(16)
-            make.left.equalToSuperview().offset(16)
-        }
-        
-        authorValueLabel.snp.makeConstraints { make in
-            make.centerY.equalTo(authorLabel)
-            make.right.equalToSuperview().offset(-16)
-        }
-        
-        dateLabelTitle.snp.makeConstraints { make in
-            make.top.equalTo(authorLabel.snp.bottom).offset(16)
-            make.left.equalToSuperview().offset(16)
-            make.bottom.equalToSuperview().offset(-16)
-        }
-        
-        dateValueLabel.snp.makeConstraints { make in
-            make.centerY.equalTo(dateLabelTitle)
-            make.right.equalToSuperview().offset(-16)
-        }
-        
-        reportReasonLabel.snp.makeConstraints { make in
-            make.top.equalTo(targetInfoView.snp.bottom).offset(32)
-            make.left.equalTo(contentView).offset(20)
-        }
-        
-        reasonCardView.snp.makeConstraints { make in
-            make.top.equalTo(reportReasonLabel.snp.bottom).offset(16)
-            make.left.right.equalToSuperview().inset(20)
-            make.height.equalTo(240)
-        }
-        
-        radioStackView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
-        
-        reportDescriptionTextView.snp.makeConstraints { make in
-            make.top.equalTo(reasonCardView.snp.bottom).offset(32)
-            make.left.right.equalTo(contentView).inset(20)
-            make.height.equalTo(200)
-        }
-        
-        reportButton.snp.makeConstraints { make in
-            make.top.equalTo(reportDescriptionTextView.snp.bottom).offset(32)
-            make.left.right.equalTo(contentView).inset(20)
-            make.bottom.equalTo(contentView).offset(-16)
-            make.height.equalTo(50)
-        }
-    }
-    
-    // MARK: - Button Actions
-    @objc private func radioButtonTapped(_ sender: UIButton) {
-        [spamButton, harmButton, abuseButton,
-         privacyButton, inappropriateButton, etcButton].forEach {
-            if $0 == sender {
-                $0.layer.borderColor = UIColor.primary.cgColor
-                let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .bold)
-                let image = UIImage(systemName: "circle.fill", withConfiguration: config)?
-                    .withTintColor(.primary, renderingMode: .alwaysOriginal)
-                $0.setImage(image, for: .normal)
-                $0.backgroundColor = .primary.withAlphaComponent(0.1)
-                selectedReason = getReasonText(for: sender)
-            } else {
-                $0.layer.borderColor = UIColor.grayCloud.cgColor
-                $0.setImage(nil, for: .normal)
-                $0.backgroundColor = .white
-            }
-        }
-    }
-    
-    private func getReasonText(for button: UIButton) -> String {
-        switch button {
-        case spamButton: return "스팸/홍보성 게시글"
-        case harmButton: return "위험 정보"
-        case abuseButton: return "욕설/비방"
-        case privacyButton: return "개인정보 노출"
-        case inappropriateButton: return "음란성/선정성"
-        case etcButton: return "기타"
-        default: return ""
-        }
-    }
-    
-    @objc private func reportButtonTapped() {
-        // 유효성 검사
-        guard let selectedReason = selectedReason else {
-            showAlert(title: "알림", message: "신고 사유를 선택해주세요.")
-            return
-        }
-        
-        let description = reportDescriptionTextView.text ?? ""
-        if description == placeholderText || description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            showAlert(title: "알림", message: "신고 내용을 입력해주세요.")
-            return
-        }
-        
-        guard let post = targetPost,
-              let reporterNickname = reporterNickname else {
-            showAlert(title: "오류", message: "필요한 정보가 누락되었습니다.")
-            return
-        }
-        
-        // Report 객체 생성
-        let report = Report(
-            reportReason: selectedReason,
-            reportDetails: description,
-            title: post.title,
-            reporterNickname: reporterNickname,
-            creationTime: ReportManager.shared.getCurrentTime(),
-            nickname: post.nickName
-        )
-        
-        // Firebase에 업로드
-        ReportManager.shared.uploadReport(report) { [weak self] result in
-            switch result {
-            case .success:
-                self?.showCompletionAlert()
-            case .failure(let error):
-                self?.showAlert(title: "오류", message: "신고 접수 중 오류가 발생했습니다: \(error.localizedDescription)")
-            }
-        }
-    }
-    
-    private func showAlert(title: String, message: String) {
-        let alert = UIAlertController(
-            title: title,
-            message: message,
-            preferredStyle: .alert
-        )
-        
-        let confirmAction = UIAlertAction(title: "확인", style: .default)
-        alert.addAction(confirmAction)
-        present(alert, animated: true)
-    }
-    
-    private func showCompletionAlert() {
-        let alert = UIAlertController(
-            title: "신고 완료",
-            message: "신고가 정상적으로 접수되었습니다.",
-            preferredStyle: .alert
-        )
-        
-        let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
-            // 현재 navigation stack에서 PostListVC 찾기
-            if let navigationController = self?.navigationController,
-               let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) {
-                // PostListVC로 한번에 이동 (중간 화면들은 스택에서 제거됨)
-                navigationController.popToViewController(postListVC, animated: true)
-            }
-        }
-        
-        alert.addAction(confirmAction)
-        present(alert, animated: true)
-    }
-    
-    // MARK: - UITextViewDelegate
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        if textView.text == placeholderText {
-            textView.text = ""
-            textView.textColor = .black
-        }
-    }
-    
-    func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            textView.text = placeholderText
-            textView.textColor = .grayCloud
-        }
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.performRequests()
     }
 }
 
-@available(iOS 17.0, *)
-#Preview {
-    // 더미 데이터로 ReportVC 초기화
-    let dummyPost = Post(
-        nickName: "테스트",
-        postType: "팀원구함",
-        title: "테스트 제목",
-        detail: "테스트 내용",
-        position: ["iOS 개발자"],
-        techStack: ["Swift"],
-        ideaStatus: "구체화됨",
-        meetingStyle: "온라인",
-        numberOfRecruits: "1명",
-        createdAt: Date(),
-        tags: [],
-        searchKeywords: []
-    )
-    return ReportVC(post: dummyPost, reporterNickname: "신고자")
+extension SignUpViewController: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
+           let identityToken = appleIDCredential.identityToken,
+           let tokenString = String(data: identityToken, encoding: .utf8),
+           let rawNonce = rawNonce {  // 저장된 rawNonce 사용
+            
+            // Apple의 userIdentifier 저장
+            UserDefaults.standard.set(appleIDCredential.user, forKey: "appleUserIdentifier")
+            
+            // Firebase 인증
+            let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: tokenString, rawNonce: rawNonce)
+            
+            Auth.auth().signIn(with: credential) { [weak self] authResult, error in
+                if let error = error {
+                    print("Firebase 인증 실패: \(error.localizedDescription)")
+                    return
+                }
+                
+                guard let user = authResult?.user else { return }
+                // 여기에 추가
+                self?.createUserDocument(for: user)
+                
+                DispatchQueue.main.async {
+                    let addUserInfoVC = AddUserInfoVC(userId: user.uid)
+                    self?.navigationController?.pushViewController(addUserInfoVC, animated: true)
+                }
+            }
+        }
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        print("Apple 로그인 실패:", error.localizedDescription)
+    }
 }
-/** TODO LIST
- () 처리 되어있는건 스크럼시 팀원들과 회의 필요
- 
- - firebase 연동 이후
- 1. 신고대상 자동작성
-    이 화면으로 넘어오면 신고한 제목 자동으로 가져오기
-    신고당하는 작성자 자동으로 가져오기 (없지만 추가 해야하는지)
-    신고글을 작성하는 작성자 닉네임 자동으로 가져오기
-    신고글을 작성하는 당일날 시간 자동으로 띄우기 (년/월/일)만
- 
- 2. 신고하기 버튼 터치후 자동으로 firebase에 데이터 자동으로 저장
- */
+
+// MARK: - Firestore에 약관 동의 상태 저장
+extension SignUpViewController {
+   func createUserDocument(for user: User) {
+       let db = Firestore.firestore()
+       let userData: [String: Any] = [
+           "id": user.uid,              // 고유 키값
+           "email": user.email ?? "",   // 애플id 이메일값
+           "createdAt": Timestamp(),    // 생성날짜
+           "termsAccepted": true        // 약관 동의
+       ]
+       
+       db.collection("users").document(user.uid).setData(userData) { error in
+           if let error = error {
+               print("사용자 문서 생성 실패: \(error)")
+           } else {
+               print("사용자 문서 생성 성공")
+           }
+       }
+   }
+}
+
+// MARK: - Nonce 생성 및 해싱
+extension SignUpViewController {
+    
+    static func randomNonceString(length: Int = 32) -> String {
+        let charset: Array<Character> = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0..<16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode == errSecSuccess {
+                    return random
+                } else {
+                    fatalError("Unable to generate nonce.")
+                }
+            }
+
+            randoms.forEach { random in
+                if remainingLength == 0 {
+                    return
+                }
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+        return result
+    }
+
+    static func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        return hashedData.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Ting/SignUp/SignUpView/SignUpViewController.swift
+++ b/Ting/SignUp/SignUpView/SignUpViewController.swift
@@ -53,6 +53,9 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
            let tokenString = String(data: identityToken, encoding: .utf8),
            let rawNonce = rawNonce {  // 저장된 rawNonce 사용
             
+            // Apple의 userIdentifier 저장
+            UserDefaults.standard.set(appleIDCredential.user, forKey: "appleUserIdentifier")
+            
             // Firebase 인증
             let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: tokenString, rawNonce: rawNonce)
             
@@ -72,10 +75,6 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
                 }
             }
         }
-    }
-    
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        print("Apple 로그인 실패:", error.localizedDescription)
     }
 }
 

--- a/Ting/SignUp/SignUpView/SignUpViewController.swift
+++ b/Ting/SignUp/SignUpView/SignUpViewController.swift
@@ -76,6 +76,10 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
             }
         }
     }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        print("Apple 로그인 실패:", error.localizedDescription)
+    }
 }
 
 // MARK: - Firestore에 약관 동의 상태 저장


### PR DESCRIPTION
## 변경사항
- 각 뷰간 nickname 데이터 객체 이동 
- 수정시 바로 업데이트 기능 구현
- detailVC 불필요 라벨 제거

## 주요내용
- Upload <-> detail <-> report 뷰 간 Nickname 객체 데이터 이동
- detailVC에서 데이터 수정시 화면내 바로 적용
- 불필요한 기존라벨 삭제


Resolves: #127 





