### PR TITLE
Fix: 로그아웃 후 재로그인 시 기존 데이터 불러오기 오류 수정

### DIFF
--- a/Ting.xcodeproj/project.pbxproj
+++ b/Ting.xcodeproj/project.pbxproj
@@ -198,7 +198,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JaegunLee.Ting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Ting;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Ting(App Group)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -236,7 +236,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JaegunLee.Ting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Ting;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Ting(App Group)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Ting/SceneDelegate.swift
+++ b/Ting/SceneDelegate.swift
@@ -51,7 +51,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     private func checkUserInfoExists(userID: String) {
         let db = Firestore.firestore()
 
-        db.collection("users").whereField("id", isEqualTo: userID).getDocuments { [weak self] snapshot, error in
+        db.collection("infos").whereField("userId", isEqualTo: userID).getDocuments { [weak self] snapshot, error in
             if let error = error {
                 print("유저 정보 확인 중 오류 발생: \(error.localizedDescription)")
                 self?.showPermissionVC()

--- a/Ting/SignUp/SignUpView/SignUpVC.swift
+++ b/Ting/SignUp/SignUpView/SignUpVC.swift
@@ -12,34 +12,32 @@ import FirebaseFirestore
 import CryptoKit
 
 class SignUpViewController: UIViewController {
-    
+
     private let signUpView = SignUpView()
     private var rawNonce: String?
-    
+
     override func loadView() {
         view = signUpView
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupActions()
-        navigationController?.navigationBar.isHidden = true // 네비게이션컨트롤러 가리는 객체
+        navigationController?.navigationBar.isHidden = true
     }
-    
-    
-    
+
     private func setupActions() {
         signUpView.appleLoginButton.addTarget(self, action: #selector(handleAppleLogin), for: .touchUpInside)
     }
-    
+
     @objc private func handleAppleLogin() {
         rawNonce = Self.randomNonceString()
-        let hashedNonce = Self.sha256(rawNonce!) // 해싱된 nonce 생성
-        
+        let hashedNonce = Self.sha256(rawNonce!)
+
         let request = ASAuthorizationAppleIDProvider().createRequest()
-        request.requestedScopes = [.fullName, .email]
-        request.nonce = hashedNonce // 애플 요청에 해시된 nonce 포함
-        
+        request.requestedScopes = [.fullName, .email,]
+        request.nonce = hashedNonce
+
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
         controller.performRequests()
@@ -51,61 +49,48 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
            let identityToken = appleIDCredential.identityToken,
            let tokenString = String(data: identityToken, encoding: .utf8),
-           let rawNonce = rawNonce {  // 저장된 rawNonce 사용
-            
-            // Apple의 userIdentifier 저장
-            UserDefaults.standard.set(appleIDCredential.user, forKey: "appleUserIdentifier")
-            
-            // Firebase 인증
+           let rawNonce = rawNonce {
+
             let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: tokenString, rawNonce: rawNonce)
-            
+
             Auth.auth().signIn(with: credential) { [weak self] authResult, error in
                 if let error = error {
                     print("Firebase 인증 실패: \(error.localizedDescription)")
                     return
                 }
-                
+
                 guard let user = authResult?.user else { return }
-                // 여기에 추가
-                self?.createUserDocument(for: user)
-                
+                UserDefaults.standard.set(user.uid, forKey: "userId")
+                UserDefaults.standard.synchronize()
+                // 새로운 UID로 Firestore에서 정확한 사용자 데이터를 가져오고 UserDefaults 덮어쓰기
+                    self?.checkExistingUserInfo(userID: user.uid)
+            }
+        }
+    }
+
+    private func checkExistingUserInfo(userID: String) {
+        let db = Firestore.firestore()
+
+        db.collection("infos").whereField("userId", isEqualTo: userID).getDocuments { [weak self] snapshot, error in
+            if let documents = snapshot?.documents, !documents.isEmpty {
+                print("기존 사용자 정보가 존재합니다. TabBar로 이동합니다.")
                 DispatchQueue.main.async {
-                    let addUserInfoVC = AddUserInfoVC(userId: user.uid)
+                    let tabBar = TabBar()
+                    self?.navigationController?.setViewControllers([tabBar], animated: true)
+                }
+            } else {
+                print("기존 사용자 정보가 없습니다. AddUserInfoVC로 이동합니다.")
+                DispatchQueue.main.async {
+                    let addUserInfoVC = AddUserInfoVC(userId: userID)
                     self?.navigationController?.pushViewController(addUserInfoVC, animated: true)
                 }
             }
         }
     }
-    
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        print("Apple 로그인 실패:", error.localizedDescription)
-    }
-}
-
-// MARK: - Firestore에 약관 동의 상태 저장
-extension SignUpViewController {
-   func createUserDocument(for user: User) {
-       let db = Firestore.firestore()
-       let userData: [String: Any] = [
-           "id": user.uid,              // 고유 키값
-           "email": user.email ?? "",   // 애플id 이메일값
-           "createdAt": Timestamp(),    // 생성날짜
-           "termsAccepted": true        // 약관 동의
-       ]
-       
-       db.collection("users").document(user.uid).setData(userData) { error in
-           if let error = error {
-               print("사용자 문서 생성 실패: \(error)")
-           } else {
-               print("사용자 문서 생성 성공")
-           }
-       }
-   }
 }
 
 // MARK: - Nonce 생성 및 해싱
 extension SignUpViewController {
-    
     static func randomNonceString(length: Int = 32) -> String {
         let charset: Array<Character> = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
         var result = ""
@@ -141,4 +126,3 @@ extension SignUpViewController {
         return hashedData.compactMap { String(format: "%02x", $0) }.joined()
     }
 }
-

--- a/Ting/Ting.entitlements
+++ b/Ting/Ting.entitlements
@@ -6,5 +6,9 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.JaegunLee.ting</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## 변경사항
- 불필요했던 fetchAndStoreUserInfo 메서드 제거
- UserDefaults에 사용자 UID 저장 위치 변경

## 주요내용
- Firestore의 users 컬렉션에서 사용자 정보를 가져오고 UserDefaults에 저장됐었던 로직을 제거한 뒤, UserDefaults에 userId를 저장한 후 checkExistingUserInfo(userId:)를 호출하는 방식으로 간소화.
- db.collection("users").document를 삭제 후 Firebase 인증 성공 시 UID 바로 저장.

## 스크린샷
.

## 추가계획, 고민
- 회원가입, 약관 동의 플로우 수정
- 게스트 로그인 구현


Resolves: #152 