### PR TITLE
Feat: 닉네임 수정 강제 문제 해결, 글자수 제한, UserDefaults 삭제

### DIFF
--- a/Ting/Models/UserInfo.swift
+++ b/Ting/Models/UserInfo.swift
@@ -13,7 +13,7 @@ struct UserInfo: Identifiable, Codable {
     @DocumentID var id: String? // Firestore 문서 ID (자동 생성)
     
     let userId: String? // Firebase user.uid 저장
-    let nickName: String  // User 모델 생성 시 User 타입으로 변경 or userID로 변경
+    let nickName: String
     let role: String
     let techStack: String
     let tool: String

--- a/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
+++ b/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
@@ -174,7 +174,7 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
                userInfo.interest
            ]
            
-           // 텍스트 필드가 전부 채워졌는지 확인.
+           // 텍스트 필드가 전부 채워졌는지 확인하고 서버에 업로드
            if isAddInfoEmpty.allSatisfy({ !$0.isEmpty }) {
                UserInfoService.shared.createUserInfo(info: userInfo) { result in
                    switch result {
@@ -211,13 +211,20 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
         textField.resignFirstResponder() // 키보드 내림
         return true
     }
+    
+    // MARK: - 글자 수 제한 20자 이하
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else { return true }
+        let newLength = text.count + string.count - range.length
+        return newLength <= 20
+    }
 }
 
 
 /*
 
 MARK: - Todo
- 닉네임 중복검사
+
  글자수 제한
  한글 영어 구분
  키보드가 텍스트 필드 가리는 부분 수정

--- a/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
+++ b/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
@@ -135,7 +135,7 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
     }
     
     
-    // MARK: - Button Actions & Firebase에 업로드
+    // MARK: - Save Button Action & Firebase에 업로드
     @objc
     private func saveBtnTapped() {
         // MARK: 닉네임 중복 검사
@@ -150,53 +150,47 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
                 }
                 return
             }
-           
-           // userInfo 객체 생성
-           let userInfo = UserInfo(
-               userId: userId,
-               nickName: nickname,
-               role: roleField.textField.text ?? "",
-               techStack: techStackField.textField.text ?? "",
-               tool: toolField.textField.text ?? "",
-               workStyle: workStyleField.textField.text ?? "",
-               location: locationField.textField.text ?? "",
-               interest: interestField.textField.text ?? ""
-           )
-               
-           // textField가 다 채워졌는지 확인하기 위해 배열에 저장
-           let isAddInfoEmpty = [
-               userInfo.nickName,
-               userInfo.role,
-               userInfo.techStack,
-               userInfo.tool,
-               userInfo.workStyle,
-               userInfo.location,
-               userInfo.interest
-           ]
-           
-           // 텍스트 필드가 전부 채워졌는지 확인하고 서버에 업로드
-           if isAddInfoEmpty.allSatisfy({ !$0.isEmpty }) {
-               UserInfoService.shared.createUserInfo(info: userInfo) { result in
-                   switch result {
-                   case .success:
-                       // UserDefaults에 Id저장
-                       UserDefaults.standard.set(userInfo.userId, forKey: "userId")
-                       
-                       // 저장된 userId출력
-                       if let savedUserId = UserDefaults.standard.string(forKey: "userId") {
-                           print("저장된 userId: \(savedUserId)")
-                       }
-                       let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
-                       sceneDelegate?.window?.rootViewController = TabBar()
-                       print("업로드 성공. | UserDefaults 저장 성공 | MainView로 이동함")
-                   case .failure(let error):
-                       print("업로드 실패: \(error)")
-                   }
-               }
-           } else {
-               basicAlert(title: "오류", message: "빈칸 없이 입력해주세요.")
-           }
-       }
+            
+            // MARK: - Firebase Create
+            // userInfo 객체 생성
+            let userInfo = UserInfo(
+                userId: userId,
+                nickName: nickNameField.textField.text ?? "",
+                role: roleField.textField.text ?? "",
+                techStack: techStackField.textField.text ?? "",
+                tool: toolField.textField.text ?? "",
+                workStyle: workStyleField.textField.text ?? "",
+                location: locationField.textField.text ?? "",
+                interest: interestField.textField.text ?? ""
+            )
+            
+            // textField가 다 채워졌는지 확인하기 위해 배열에 저장
+            let isAddInfoEmpty = [
+                userInfo.nickName,
+                userInfo.role,
+                userInfo.techStack,
+                userInfo.tool,
+                userInfo.workStyle,
+                userInfo.location,
+                userInfo.interest
+            ]
+            
+            // 텍스트 필드가 전부 채워졌는지 확인하고 서버에 업로드
+            if isAddInfoEmpty.allSatisfy({ !$0.isEmpty }) {
+                UserInfoService.shared.createUserInfo(info: userInfo) { result in
+                    switch result {
+                    case .success:
+                        let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+                        sceneDelegate?.window?.rootViewController = TabBar() // 메인화면으로 이동
+                        print("업로드 성공. | UserDefaults 저장 성공 | MainView로 이동함")
+                    case .failure(let error):
+                        print("업로드 실패: \(error)")
+                    }
+                }
+            } else {
+                basicAlert(title: "오류", message: "빈칸 없이 입력해주세요.")
+            }
+        }
     }
     
     // MARK: 키보드 설정

--- a/Ting/MyPage/EditInfo/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfo/EditInfoVC.swift
@@ -236,6 +236,13 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
         textField.resignFirstResponder() // 키보드 내림
         return true
     }
+    
+    // MARK: - 글자 수 제한 20자 이하
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else { return true }
+        let newLength = text.count + string.count - range.length
+        return newLength <= 20
+    }
 }
 
 extension EditCustomView {

--- a/Ting/MyPage/EditInfo/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfo/EditInfoVC.swift
@@ -17,7 +17,8 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
     private let scrollView = UIScrollView()
     private let contentView = UIView()
     private let userId: String
-    
+    private var originalNickName: String?
+        
     init(userId: String) {
         self.userId = userId
         super.init(nibName: nil, bundle: nil)
@@ -133,7 +134,7 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
         }
     }
     
-    // MARK: - Firebase Data Fetching
+    // MARK: - Firebase Data Fetching (Read)
     // 서버에서 데이터 받아와서 텍스트 필드에 기존 데이터 출력
     private func fetchUserData() {
         UserInfoService.shared.fetchUserInfo { [weak self] result in
@@ -142,6 +143,7 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
             case .success(let userInfo):
                 DispatchQueue.main.async {
                     self.showPreviousInfo(with: userInfo)
+                    self.originalNickName = userInfo.nickName
                 }
             case .failure(let error):
                 print("데이터 가져오기 실패: \(error.localizedDescription)")
@@ -160,67 +162,76 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
         interestField.updateDetailText(userInfo.interest)
     }
     
-    // MARK: - Button Actions
+    // MARK: - Save Button Action
     @objc
     private func saveBtnTapped() {
         // MARK: 닉네임 중복 검사
-        let nickname = nickNameField.textField.text ?? ""
+        let nickname = nickNameField.textField.text ?? "" // 현재 텍스트 필드에 있는 값(닉네임)
         
-        UserInfoService.shared.checkNicknameDuplicate(nickname: nickname) { [weak self] isDuplicate in
-            guard let self = self else { return }
-            
-            if isDuplicate {
-                DispatchQueue.main.async {
-                    self.basicAlert(title: "오류", message: "중복된 닉네임입니다.\n 다른 닉네임을 입력해 주세요.")
+        // nickname textField안의 값이 기존 값과 같으면 중복검사 생략
+        if nickname == originalNickName {
+            saveUserInfo()
+            print("닉네임 변경 없음. 중복검사 생략")
+        } else {
+            UserInfoService.shared.checkNicknameDuplicate(nickname: nickname) { [weak self] isDuplicate in
+                guard let self = self else { return }
+                
+                if isDuplicate {
+                    DispatchQueue.main.async {
+                        self.basicAlert(title: "오류", message: "중복된 닉네임입니다.\n 다른 닉네임을 입력해 주세요.")
+                    }
+                    return
                 }
-                return
             }
-            
-            // userInfo 객체 생성
-            let updatedUserInfo = UserInfo(
-                userId: userId,
-                nickName: nickname,
-                role: roleField.textField.text ?? "",
-                techStack: techStackField.textField.text ?? "",
-                tool: toolField.textField.text ?? "",
-                workStyle: workStyleField.textField.text ?? "",
-                location: locationField.textField.text ?? "",
-                interest: interestField.textField.text ?? ""
-            )
-            
-            // textField가 다 채워졌는지 확인하기 위해 배열에 저장
-            let isUpdateInfoEmpty = [
-                updatedUserInfo.nickName,
-                updatedUserInfo.role,
-                updatedUserInfo.techStack,
-                updatedUserInfo.tool,
-                updatedUserInfo.workStyle,
-                updatedUserInfo.location,
-                updatedUserInfo.interest
-            ]
-            
-            // MARK: 회원정보 업데이트
-            if isUpdateInfoEmpty.allSatisfy({ !$0.isEmpty }) {
-                UserInfoService.shared.updateUserInfo(userInfo: updatedUserInfo) { [weak self] result in
-                    switch result {
-                    case .success:
-                        // 저장 성공 후 Notification 보내기
-                        NotificationCenter.default.post(name: .userInfoUpdated, object: nil)
-                        
-                        // 마이페이지로 돌아가기
-                        DispatchQueue.main.async {
-                            self?.navigationController?.popViewController(animated: true)
-                        }
-                        print("수정 성공. | MainView로 이동함")
-                    case .failure(let error):
-                        DispatchQueue.main.async {
-                            self?.basicAlert(title: "오류", message: "회원정보 수정에 실패했습니다. \(error.localizedDescription)")
-                        }
+        }
+    }
+    
+    // MARK: - 변경된 회원정보 서버에 업로드 Firebase Update
+    private func saveUserInfo() {
+        // userInfo 객체 생성
+        let updatedUserInfo = UserInfo(
+            userId: userId,
+            nickName: nickNameField.textField.text ?? "",
+            role: roleField.textField.text ?? "",
+            techStack: techStackField.textField.text ?? "",
+            tool: toolField.textField.text ?? "",
+            workStyle: workStyleField.textField.text ?? "",
+            location: locationField.textField.text ?? "",
+            interest: interestField.textField.text ?? ""
+        )
+        
+        // textField가 다 채워졌는지 확인하기 위해 배열에 저장
+        let isUpdateInfoEmpty = [
+            updatedUserInfo.nickName,
+            updatedUserInfo.role,
+            updatedUserInfo.techStack,
+            updatedUserInfo.tool,
+            updatedUserInfo.workStyle,
+            updatedUserInfo.location,
+            updatedUserInfo.interest
+        ]
+        
+        // MARK: 회원정보 업데이트 Firebase Update
+        if isUpdateInfoEmpty.allSatisfy({ !$0.isEmpty }) {
+            UserInfoService.shared.updateUserInfo(userInfo: updatedUserInfo) { [weak self] result in
+                switch result {
+                case .success:
+                    // 저장 성공 후 Notification 보내기
+                    NotificationCenter.default.post(name: .userInfoUpdated, object: nil)
+                    
+                    // 마이페이지로 돌아가기
+                    DispatchQueue.main.async {
+                        self?.navigationController?.popViewController(animated: true)
+                    }
+                    print("수정 성공. | MainView로 이동함")
+                case .failure(let error):
+                    DispatchQueue.main.async {
+                        self?.basicAlert(title: "오류", message: "회원정보 수정에 실패했습니다. \(error.localizedDescription)")
                     }
                 }
-            } else {
-                basicAlert(title: "오류", message: "빈칸 없이 입력해주세요.")
             }
+        } else {
+            basicAlert(title: "오류", message: "빈칸 없이 입력해주세요.")
         }
     }
     

--- a/Ting/MyPage/MyPageMain/MyPageMainVC.swift
+++ b/Ting/MyPage/MyPageMain/MyPageMainVC.swift
@@ -171,7 +171,7 @@ class MyPageMainVC: UIViewController {
         contentView.addSubview(profileCard)
         profileCard.snp.makeConstraints {
             $0.top.equalToSuperview().offset(20)
-            $0.leading.trailing.equalToSuperview().inset(10)
+            $0.leading.trailing.equalToSuperview().inset(16)
         }
         profileCard.addSubview(profileStack) // profileStack = 이름, 직군
         profileStack.snp.makeConstraints {
@@ -182,7 +182,7 @@ class MyPageMainVC: UIViewController {
         contentView.addSubview(textFieldCard)
         textFieldCard.snp.makeConstraints {
             $0.top.equalTo(profileCard.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(10)
+            $0.leading.trailing.equalToSuperview().inset(16)
             $0.bottom.equalToSuperview().offset(-20)
         }
         textFieldCard.addSubview(textFieldStack) // textFieldStack = 텍스트 필드 항목들
@@ -194,7 +194,7 @@ class MyPageMainVC: UIViewController {
         view.addSubview(btnStackView)
         btnStackView.snp.makeConstraints {
             $0.top.equalTo(scrollView.snp.bottom).offset(10)
-            $0.leading.trailing.equalToSuperview().inset(10)
+            $0.leading.trailing.equalToSuperview().inset(16)
         }
         // 버튼 높이 설정
         editBtn.snp.makeConstraints {
@@ -252,7 +252,7 @@ class MyPageMainVC: UIViewController {
             
             // 3. 로그인 화면으로 이동
             let firstView = PermissionVC()
-            let navController = UINavigationController(rootViewController: PermissionVC())
+            let navController = UINavigationController(rootViewController: firstView)
             
             // 현재 창을 로그인 화면으로 변경
             if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {


### PR DESCRIPTION
## 변경사항
### MyPageMain
- inset을 `10`에서 `16`으로 수정했습니다.
### AddUserInfo
- 글자수 20자 제한을 추가했습니다.
- 코드의 간격을 수정했습니다
- UserDefaults에 userId를 저장하는 코드를 삭제했습니다. (로그인 시로 저장위치 변경)
### EditInfoVC
- 회원정보 수정시 닉네임 수정을 강제하는 문제를 해결했습니다.

## 주요내용
`EditInfoVC`에서 회원정보를 수정할 때, 닉네임 변경을 강제하는 현상이 있었습니다.
따라서, 현재 nickname textField에 있는 값과 서버에 있는 값을 비교해서,
동일하다면 -> 닉네임 변경사항 없음. 중복검사 생략
다르다면 -> 닉네임 변경사항 있음. 중복검사 시작

위의 로직으로 수정하였습니다.

## 스크린샷
### MyPageMain inset 수정
<img width="568" alt="스크린샷 2025-02-11 오후 9 38 30" src="https://github.com/user-attachments/assets/1502c610-e7a6-4420-888e-3848b17de710" />

### 닉네임 변동 없을 시 콘솔창
<img width="323" alt="스크린샷 2025-02-11 오후 9 38 18" src="https://github.com/user-attachments/assets/a788f508-c70a-4a30-8e10-0d153e131557" />
<img width="400" alt="" src=" " />

## 추가계획, 고민
- 각 사항별 예외처리 추가. (한글만 사용가능, 공백 사용 불가 등)

Resolves: #151