### PR TITLE
Fix: 작성,수정시 게시글리스트 새로고침 delegate 추가, UI 일부 수정

### DIFF
--- a/Ting/CustomView/CustomTag.swift
+++ b/Ting/CustomView/CustomTag.swift
@@ -39,5 +39,6 @@ final class CustomTag: UIButton {
         config.background.strokeWidth = 0.5
         self.configuration = config
         isUserInteractionEnabled = isButton
+        clipsToBounds = true
     }
 }

--- a/Ting/Main/MainView/MainVC.swift
+++ b/Ting/Main/MainView/MainVC.swift
@@ -77,7 +77,7 @@ class MainVC: UIViewController, UISearchBarDelegate {
         let layout = createLayout() // 컴포지셔널 레이아웃 생성
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .clear
-        collectionView.isScrollEnabled = false
+        collectionView.showsVerticalScrollIndicator = false
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.register(MainViewCell.self, forCellWithReuseIdentifier: MainViewCell.identifier)
         collectionView.register(HeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HeaderView.identifier)

--- a/Ting/Post/PostView/JoinTeamUploadVC.swift
+++ b/Ting/Post/PostView/JoinTeamUploadVC.swift
@@ -9,6 +9,10 @@
 import UIKit
 import SnapKit
 
+protocol PostListUpdater: AnyObject {
+    func didUpdatePostList()
+}
+
 protocol PostUpdateDelegate: AnyObject {
     func didUpdatePost(_ updatedPost: Post)
 }
@@ -27,7 +31,8 @@ final class JoinTeamUploadVC: UIViewController {
     var selectedMeetingStyle = ""
     var selectedCurrentStatus = ""
     
-    weak var delegate: PostUpdateDelegate?
+    weak var updateDelegate: PostUpdateDelegate?
+    weak var listDelegate: PostListUpdater?
     var isEditMode = false
     var editPostId: String?
     
@@ -113,7 +118,8 @@ final class JoinTeamUploadVC: UIViewController {
                         switch result {
                         case .success:
                             // 업데이트 성공 시 delegate로 수정된 post 전달
-                            self?.delegate?.didUpdatePost(post)
+                            self?.listDelegate?.didUpdatePostList()
+                            self?.updateDelegate?.didUpdatePost(post)
                             self?.navigationController?.popViewController(animated: true)
                         case .failure(let error):
                             print("\(error)")
@@ -125,10 +131,7 @@ final class JoinTeamUploadVC: UIViewController {
                     PostService.shared.uploadPost(post: post) { [weak self] result in
                         switch result {
                         case .success:
-                            if let navigationController = self?.navigationController,
-                               let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) as? PostListVC {
-                                postListVC.loadInitialData()
-                            }
+                            self?.listDelegate?.didUpdatePostList()
                             self?.navigationController?.popViewController(animated: true)
                         case .failure(let error):
                             print("\(error)")

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -355,7 +355,7 @@ class PostDetailVC: UIViewController, PostUpdateDelegate {
                 let uploadVC = RecruitMemberUploadVC()
                 uploadVC.isEditMode = true
                 uploadVC.editPostId = post.id
-                uploadVC.delegate = self
+                uploadVC.updateDelegate = self
                 
                 // 기존 데이터 설정
                 uploadVC.selectedPositions = post.position
@@ -377,6 +377,7 @@ class PostDetailVC: UIViewController, PostUpdateDelegate {
                 uploadVC.uploadView.recruitsSection.setSelectedTag(titles: [post.numberOfRecruits])
                 uploadVC.uploadView.meetingStyleSection.setSelectedTag(titles: [post.meetingStyle])
                 uploadVC.uploadView.experienceSection.setSelectedTag(titles: [post.experience ?? ""])
+                uploadVC.uploadView.submitButton.titleLabel?.text = "수정하기"
                 
                 self.navigationController?.pushViewController(uploadVC, animated: true)
                 
@@ -384,7 +385,7 @@ class PostDetailVC: UIViewController, PostUpdateDelegate {
                 let uploadVC = JoinTeamUploadVC()
                 uploadVC.isEditMode = true
                 uploadVC.editPostId = post.id
-                uploadVC.delegate = self
+                uploadVC.updateDelegate = self
                 
                 // 기존 데이터 설정
                 uploadVC.selectedPositions = post.position
@@ -406,6 +407,7 @@ class PostDetailVC: UIViewController, PostUpdateDelegate {
                 uploadVC.uploadView.teamSizeSection.setSelectedTag(titles: [post.numberOfRecruits])
                 uploadVC.uploadView.meetingStyleSection.setSelectedTag(titles: [post.meetingStyle])
                 uploadVC.uploadView.currentStatusSection.setSelectedTag(titles: [post.currentStatus ?? ""])
+                uploadVC.uploadView.submitButton.titleLabel?.text = "수정하기"
                 
                 self.navigationController?.pushViewController(uploadVC, animated: true)
             }

--- a/Ting/Post/PostView/PostListVC.swift
+++ b/Ting/Post/PostView/PostListVC.swift
@@ -44,11 +44,6 @@ final class PostListVC: UIViewController {
         loadInitialData()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        refreshData() // 이미 구현된 새로고침 메서드 재사용
-    }
-    
     private func setupCollectionView() {
         postListView.collectionView.dataSource = self
         postListView.collectionView.delegate = self
@@ -87,11 +82,13 @@ final class PostListVC: UIViewController {
         case .recruitMember:
             // 팀원 모집 글작성 뷰컨
             let uploadVC = RecruitMemberUploadVC()
+            uploadVC.listDelegate = self
             navigationController?.pushViewController(uploadVC, animated: true)
             
         case .joinTeam:
             // 팀 합류 글작성 뷰컨
             let uploadVC = JoinTeamUploadVC()
+            uploadVC.listDelegate = self
             navigationController?.pushViewController(uploadVC, animated: true)
         case .none:
             return
@@ -151,6 +148,7 @@ final class PostListVC: UIViewController {
     }
 }
 
+// MARK: - 셀 dataSource
 extension PostListVC: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         /// TODO - Rx 적용, 서버로 부터 데이터 받아오기 (몇개까지 받아올지, 페이징처리 할지 고민)
@@ -206,6 +204,7 @@ extension PostListVC: UICollectionViewDataSource {
     }
 }
 
+// MARK: - 셀 선택 시 delegate
 extension PostListVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let post = postList[indexPath.row]
@@ -252,5 +251,12 @@ extension PostListVC: UICollectionViewDelegateFlowLayout {
     }
 }
 
+// MARK: - 리스트 새로고침 delegate
+extension PostListVC: PostListUpdater {
+    func didUpdatePostList() {
+        // 데이터 새로고침 로직
+        loadInitialData()
+    }
+}
 /// prefetchItemAt 알아보고 적용해보기
 /// hasMoreData, reload 관련 코드 수정 필요

--- a/Ting/Post/PostView/RecruitMemberUploadVC.swift
+++ b/Ting/Post/PostView/RecruitMemberUploadVC.swift
@@ -23,7 +23,8 @@ final class RecruitMemberUploadVC: UIViewController {
     var selectedMeetingStyle = ""
     var selectedExperience = ""
     
-    weak var delegate: PostUpdateDelegate?
+    weak var updateDelegate: PostUpdateDelegate?
+    weak var listDelegate: PostListUpdater?
     var isEditMode = false
     var editPostId: String?
     
@@ -113,7 +114,8 @@ final class RecruitMemberUploadVC: UIViewController {
                         switch result {
                         case .success:
                             // delegate를 통해 수정된 포스트 전달
-                            self?.delegate?.didUpdatePost(post)
+                            self?.listDelegate?.didUpdatePostList()
+                            self?.updateDelegate?.didUpdatePost(post)
                             self?.navigationController?.popViewController(animated: true)
                         case .failure(let error):
                             print("\(error)")
@@ -125,10 +127,7 @@ final class RecruitMemberUploadVC: UIViewController {
                     PostService.shared.uploadPost(post: post) { [weak self] result in
                         switch result {
                         case .success:
-                            if let navigationController = self?.navigationController,
-                               let postListVC = navigationController.viewControllers.first(where: { $0 is PostListVC }) as? PostListVC {
-                                postListVC.loadInitialData()
-                            }
+                            self?.listDelegate?.didUpdatePostList()
                             self?.navigationController?.popViewController(animated: true)
                         case .failure(let error):
                             print("\(error)")


### PR DESCRIPTION
## 변경사항
- UI : 태그버튼 clipsToBounds 적용, 메인 세로스크롤 적용 ( 작은기기 대응)
- 작성하기, 수정하기 이후 리스트 새로고침 delegate로 로직 변경 ( listDelegate )
- 기존 태호님이 구현해주신 delegate -> updateDelegate로 변경
- listDelegate 추가

## 주요내용
- 위와 동일

## 추가계획, 고민
- 수정 이후 서버에서 데이터 받아와야 할듯
- 삭제 기능 추가 필요
- 메인 셀 클릭시에도 동일적용 필요

Resolves: #164