### PR TITLE
Feat: 비회원 로그인 구현

### DIFF
--- a/Ting/MyPage/DeleteInfo/DeleteInfoVC.swift
+++ b/Ting/MyPage/DeleteInfo/DeleteInfoVC.swift
@@ -62,13 +62,13 @@ class DeleteInfoVC: UIViewController {
     
     // Firebase가 Apple의 idToken 검증 시 nonce 비교
     lazy var rawNonce: String = {
-        return SignUpViewController.randomNonceString()
+        return SignUpVC.randomNonceString()
     }()
     
     // idToken 내부 해시값
     lazy var hashedNonce: String = {
         // self.rawNonce에 접근하여 해싱
-        return SignUpViewController.sha256(self.rawNonce)
+        return SignUpVC.sha256(self.rawNonce)
     }()
     
     // 현재 체크 상태 저장
@@ -235,7 +235,7 @@ class DeleteInfoVC: UIViewController {
                 // 4. 회원 탈퇴 후 첫 화면으로 이동
                 DispatchQueue.main.async {
                     if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
-                        let signupVC = SignUpViewController()
+                        let signupVC = SignUpVC()
                         let navigationController = UINavigationController(rootViewController: signupVC)
                         
                         sceneDelegate.window?.rootViewController = navigationController

--- a/Ting/MyPage/MyPageMain/MyPageMainVC.swift
+++ b/Ting/MyPage/MyPageMain/MyPageMainVC.swift
@@ -251,7 +251,7 @@ class MyPageMainVC: UIViewController {
             print("UserDefaults 삭제 성공. | 삭제된 UserDefaults: ")
             
             // 3. 로그인 화면으로 이동
-            let firstView = PermissionVC()
+            let firstView = SignUpVC()
             let navController = UINavigationController(rootViewController: firstView)
             
             // 현재 창을 로그인 화면으로 변경

--- a/Ting/SceneDelegate.swift
+++ b/Ting/SceneDelegate.swift
@@ -76,7 +76,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     private func showSignUpVC() {
-        let signUpVC = SignUpViewController()
+        let signUpVC = SignUpVC()
         let navController = UINavigationController(rootViewController: signUpVC)
         window?.rootViewController = navController
     }

--- a/Ting/SignUp/SignUpView/SignUpVC.swift
+++ b/Ting/SignUp/SignUpView/SignUpVC.swift
@@ -1,5 +1,5 @@
 //
-//  SignUpViewController.swift
+//  SignUpVC.swift
 //  Ting
 //
 //  Created by Sol on 1/21/25.
@@ -11,7 +11,7 @@ import FirebaseAuth
 import FirebaseFirestore
 import CryptoKit
 
-class SignUpViewController: UIViewController {
+class SignUpVC: UIViewController {
 
     private let signUpView = SignUpView()
     private var rawNonce: String?
@@ -44,7 +44,7 @@ class SignUpViewController: UIViewController {
     }
 }
 
-extension SignUpViewController: ASAuthorizationControllerDelegate {
+extension SignUpVC: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
            let identityToken = appleIDCredential.identityToken,
@@ -127,7 +127,7 @@ extension SignUpViewController: ASAuthorizationControllerDelegate {
 }
 
 // MARK: - Nonce 생성 및 해싱
-extension SignUpViewController {
+extension SignUpVC {
     static func randomNonceString(length: Int = 32) -> String {
         let charset: Array<Character> = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
         var result = ""

--- a/Ting/SignUp/SignUpView/SignUpView.swift
+++ b/Ting/SignUp/SignUpView/SignUpView.swift
@@ -34,6 +34,19 @@ class SignUpView: UIView {
         $0.cornerRadius = 10
     }
     
+    // 비로그인으로 시작하기 버튼
+    private lazy var guestLoginBtn = UIButton().then {
+        $0.setTitle("로그인 없이 둘러만 볼게요", for: .normal)
+        $0.layer.cornerRadius = 10
+        $0.backgroundColor = .background
+        $0.layer.borderColor = UIColor.accent.cgColor // 테두리 색 설정
+        $0.layer.borderWidth = 2 // 테두리 두께 설정
+        $0.setTitleColor(.accent, for: .normal)
+        $0.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
+        
+        $0.addTarget(self, action: #selector(guestBtnTapped), for: .touchUpInside)
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI() // UI 요소 배치
@@ -50,6 +63,7 @@ class SignUpView: UIView {
         addSubview(titleLabel)
         addSubview(nameLabel)
         addSubview(appleLoginButton)
+        addSubview(guestLoginBtn)
         
         // 제목 레이블 위치 설정
         titleLabel.snp.makeConstraints {
@@ -65,10 +79,26 @@ class SignUpView: UIView {
         
         // Apple 로그인 버튼 위치 설정 (화면 하단 가까이 배치)
         appleLoginButton.snp.makeConstraints {
-            $0.bottom.equalTo(safeAreaLayoutGuide).offset(-80)
+            $0.bottom.equalTo(safeAreaLayoutGuide).offset(-96)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(280)
             $0.height.equalTo(50)
+        }
+        
+        // 게스트 로그인 버튼
+        guestLoginBtn.snp.makeConstraints {
+            $0.top.equalTo(appleLoginButton.snp.bottom).offset(15)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(280)
+            $0.height.equalTo(50)
+        }
+    }
+    
+    // MARK: - Button Action
+    @objc // 게스트 로그인 버튼 클릭시 액션
+    private func guestBtnTapped() {
+        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+            sceneDelegate.window?.rootViewController = TabBar()
         }
     }
 }


### PR DESCRIPTION
## 변경사항
- 비회원 로그인을 구현했습니다.
- 버튼의 위치는 애플로그인 하단에 배치했습니다.
- `SignUpViewController`클래스의 이름을 변경하였습니다. -> `SignUpVC`
- 로그아웃 시 이동되면 화면을 `SignUpVC`로 변경하였습니다

## 주요내용
- 비회원 로그인을 클릭 시, 로그인 없이 메인화면으로 넘어가게 구현하였습니다.
- 클래스 이름을 변경하면서, 해당 이름을 사용하던 부가적인 코드도 전부 변경하였습니다.

## 스크린샷
<img width="568" alt="스크린샷 2025-02-11 오후 10 32 46" src="https://github.com/user-attachments/assets/fa988774-adda-4283-87d1-1549580aa107" />


## 추가계획, 고민
- 비회원일 때, 게시글 작성, 신고, 회원정보 수정 등을 하지 못하도록 로직처리가 필요합니다.
- 비회원일 때, 마이페이지에 접근하지 못하도록 하는 로직이 필요합니다.


Resolves: #161 