### PR TITLE
Fix: 수정하기 버튼타이틀, 탈퇴시 UserDefaults 삭제, 비회원 화면이동 수정

### DIFF
--- a/Ting/Extension/LoginCheck+Alert.swift
+++ b/Ting/Extension/LoginCheck+Alert.swift
@@ -17,10 +17,13 @@ extension UIViewController {
             let alert = UIAlertController(title: "로그인이 필요합니다.", message: "로그인을 하시겠습니까?", preferredStyle: .alert)
             
             let confirm = UIAlertAction(title: "확인", style: .default) { _ in
-                let signUpVC = SignUpVC()
-                let navController = UINavigationController(rootViewController: signUpVC)
-                navController.modalPresentationStyle = .fullScreen
-                self.present(navController, animated: true)
+                if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+                    let signupVC = SignUpVC()
+                    let navigationController = UINavigationController(rootViewController: signupVC)
+                    
+                    sceneDelegate.window?.rootViewController = navigationController
+                    sceneDelegate.window?.makeKeyAndVisible()
+                }
             }
             
             let cancel = UIAlertAction(title: "취소", style: .cancel)

--- a/Ting/MyPage/DeleteInfo/DeleteInfoVC.swift
+++ b/Ting/MyPage/DeleteInfo/DeleteInfoVC.swift
@@ -232,7 +232,12 @@ class DeleteInfoVC: UIViewController {
             } else {
                 print("Firebase Auth 계정 삭제 성공!")
                 
-                // 4. 회원 탈퇴 후 첫 화면으로 이동
+                // 4. UserDefaults 정보 삭제
+                UserDefaults.standard.removeObject(forKey: "userId")
+                UserDefaults.standard.synchronize()
+                print("UserDefaults 삭제 성공. | 삭제된 UserDefaults: ")
+                
+                // 5. 회원 탈퇴 후 첫 화면으로 이동
                 DispatchQueue.main.async {
                     if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
                         let signupVC = SignUpVC()

--- a/Ting/Post/PostView/JoinTeamUploadVC.swift
+++ b/Ting/Post/PostView/JoinTeamUploadVC.swift
@@ -13,10 +13,6 @@ protocol PostListUpdater: AnyObject {
     func didUpdatePostList()
 }
 
-protocol PostUpdateDelegate: AnyObject {
-    func didUpdatePost(_ updatedPost: Post)
-}
-
 final class JoinTeamUploadVC: UIViewController {
     
     let uploadView = JoinTeamUploadView()
@@ -31,8 +27,7 @@ final class JoinTeamUploadVC: UIViewController {
     var selectedMeetingStyle = ""
     var selectedCurrentStatus = ""
     
-    weak var updateDelegate: PostUpdateDelegate?
-    weak var listDelegate: PostListUpdater?
+    weak var delegate: PostListUpdater?
     var isEditMode = false
     var editPostId: String?
     
@@ -117,9 +112,6 @@ final class JoinTeamUploadVC: UIViewController {
                     PostService.shared.updatePost(id: postId, post: post) { [weak self] result in
                         switch result {
                         case .success:
-                            // 업데이트 성공 시 delegate로 수정된 post 전달
-                            self?.listDelegate?.didUpdatePostList()
-                            self?.updateDelegate?.didUpdatePost(post)
                             self?.navigationController?.popViewController(animated: true)
                         case .failure(let error):
                             print("\(error)")
@@ -131,7 +123,7 @@ final class JoinTeamUploadVC: UIViewController {
                     PostService.shared.uploadPost(post: post) { [weak self] result in
                         switch result {
                         case .success:
-                            self?.listDelegate?.didUpdatePostList()
+                            self?.delegate?.didUpdatePostList()
                             self?.navigationController?.popViewController(animated: true)
                         case .failure(let error):
                             print("\(error)")

--- a/Ting/Post/PostView/JoinTeamUploadVC.swift
+++ b/Ting/Post/PostView/JoinTeamUploadVC.swift
@@ -9,10 +9,6 @@
 import UIKit
 import SnapKit
 
-protocol PostListUpdater: AnyObject {
-    func didUpdatePostList()
-}
-
 final class JoinTeamUploadVC: UIViewController {
     
     let uploadView = JoinTeamUploadView()

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -397,7 +397,7 @@ class PostDetailVC: UIViewController {
                 uploadVC.uploadView.recruitsSection.setSelectedTag(titles: [post.numberOfRecruits])
                 uploadVC.uploadView.meetingStyleSection.setSelectedTag(titles: [post.meetingStyle])
                 uploadVC.uploadView.experienceSection.setSelectedTag(titles: [post.experience ?? ""])
-                uploadVC.uploadView.submitButton.titleLabel?.text = "수정하기"
+                uploadVC.uploadView.submitButton.setTitle("수정하기", for: .normal)
                 
                 self.navigationController?.pushViewController(uploadVC, animated: true)
                 
@@ -426,7 +426,7 @@ class PostDetailVC: UIViewController {
                 uploadVC.uploadView.teamSizeSection.setSelectedTag(titles: [post.numberOfRecruits])
                 uploadVC.uploadView.meetingStyleSection.setSelectedTag(titles: [post.meetingStyle])
                 uploadVC.uploadView.currentStatusSection.setSelectedTag(titles: [post.currentStatus ?? ""])
-                uploadVC.uploadView.submitButton.titleLabel?.text = "수정하기"
+                uploadVC.uploadView.submitButton.setTitle("수정하기", for: .normal)
                 
                 self.navigationController?.pushViewController(uploadVC, animated: true)
             }

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -30,6 +30,7 @@ class PostDetailVC: UIViewController {
     private let postType: PostType
     private var post: Post?
     private let currentUserNickname: String
+    weak var delegate: PostListUpdater?
     
     // MARK: - Initialization
     init(postType: PostType, post: Post, currentUserNickname: String) {
@@ -448,6 +449,7 @@ class PostDetailVC: UIViewController {
                     case .success:
                         // 삭제 성공 시 이전 화면으로 돌아가기
                         DispatchQueue.main.async {
+                            self?.delegate?.didUpdatePostList()
                             self?.navigationController?.popViewController(animated: true)
                         }
                     case .failure(let error):

--- a/Ting/Post/PostView/PostListVC.swift
+++ b/Ting/Post/PostView/PostListVC.swift
@@ -85,13 +85,13 @@ final class PostListVC: UIViewController {
         case .recruitMember:
             // 팀원 모집 글작성 뷰컨
             let uploadVC = RecruitMemberUploadVC()
-            uploadVC.listDelegate = self
+            uploadVC.delegate = self
             navigationController?.pushViewController(uploadVC, animated: true)
             
         case .joinTeam:
             // 팀 합류 글작성 뷰컨
             let uploadVC = JoinTeamUploadVC()
-            uploadVC.listDelegate = self
+            uploadVC.delegate = self
             navigationController?.pushViewController(uploadVC, animated: true)
         case .none:
             return
@@ -226,6 +226,7 @@ extension PostListVC: UICollectionViewDelegate {
                     let postDetailVC = PostDetailVC(postType: postType,
                                                  post: post,
                                                  currentUserNickname: userInfo.nickName)
+                    postDetailVC.delegate = self
                     self.navigationController?.pushViewController(postDetailVC, animated: true)
                 }
                 
@@ -259,6 +260,7 @@ extension PostListVC: PostListUpdater {
     func didUpdatePostList() {
         // 데이터 새로고침 로직
         loadInitialData()
+        print("새로고침")
     }
 }
 /// prefetchItemAt 알아보고 적용해보기

--- a/Ting/Post/PostView/PostListVC.swift
+++ b/Ting/Post/PostView/PostListVC.swift
@@ -9,6 +9,10 @@ import UIKit
 import SnapKit
 import FirebaseFirestore
 
+protocol PostListUpdater: AnyObject {
+    func didUpdatePostList()
+}
+
 final class PostListVC: UIViewController {
     
     private let postListView = PostListView()
@@ -260,7 +264,6 @@ extension PostListVC: PostListUpdater {
     func didUpdatePostList() {
         // 데이터 새로고침 로직
         loadInitialData()
-        print("새로고침")
     }
 }
 /// prefetchItemAt 알아보고 적용해보기

--- a/Ting/Post/PostView/RecruitMemberUploadVC.swift
+++ b/Ting/Post/PostView/RecruitMemberUploadVC.swift
@@ -22,9 +22,8 @@ final class RecruitMemberUploadVC: UIViewController {
     var selectedRecruits = ""
     var selectedMeetingStyle = ""
     var selectedExperience = ""
-    
-    weak var updateDelegate: PostUpdateDelegate?
-    weak var listDelegate: PostListUpdater?
+
+    weak var delegate: PostListUpdater?
     var isEditMode = false
     var editPostId: String?
     
@@ -113,9 +112,6 @@ final class RecruitMemberUploadVC: UIViewController {
                     PostService.shared.updatePost(id: postId, post: post) { [weak self] result in
                         switch result {
                         case .success:
-                            // delegate를 통해 수정된 포스트 전달
-                            self?.listDelegate?.didUpdatePostList()
-                            self?.updateDelegate?.didUpdatePost(post)
                             self?.navigationController?.popViewController(animated: true)
                         case .failure(let error):
                             print("\(error)")
@@ -127,7 +123,7 @@ final class RecruitMemberUploadVC: UIViewController {
                     PostService.shared.uploadPost(post: post) { [weak self] result in
                         switch result {
                         case .success:
-                            self?.listDelegate?.didUpdatePostList()
+                            self?.delegate?.didUpdatePostList()
                             self?.navigationController?.popViewController(animated: true)
                         case .failure(let error):
                             print("\(error)")


### PR DESCRIPTION
## 변경사항
- 편집하기 -> 수정하기로 작성뷰 진입 시 버튼 타이틀 바뀌도록 수정
- 탈퇴 시 UserDefaults 삭제 추가
- 비회원일 경우 알럿 확인 이후 화면 이동 방식 수정
- detailVC에서 delegate -> viewWillAppear로 변경에 따른
listVC에 기존 사용하던 불필요한 delegate 코드 삭제 및 listDelegate -> delegate로 다시 변경
- 게시글 삭제 시 새로고침 기능 추가

## 주요내용
- 회원 탈퇴 시에도 UserDefaults 의 userId 삭제 코드 추가
- loginCheck 메서드 내에서 확인 눌렀을 때 모달 present 가 아닌 
sceneDelegate.window?.rootViewController를 새로 할당
이전 방식은 메모리가 남아있을 수 있기에 해당 방식으로 변경. ( 초기화 )
- 수정 시 리스트 새로고침은 삭제함.
( 수정 시 리스트로 돌아오는 것이 아니기에 바로 적용이 안되어 삭제 )

Resolves: #173 