### PR TITLE
Fix: 경고문 삭제 (OAuth 인증 구조)

### DIFF
--- a/Ting/SignUp/SignUpView/SignUpVC.swift
+++ b/Ting/SignUp/SignUpView/SignUpVC.swift
@@ -51,8 +51,12 @@ extension SignUpVC: ASAuthorizationControllerDelegate {
            let tokenString = String(data: identityToken, encoding: .utf8),
            let rawNonce = rawNonce {
 
-            let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: tokenString, rawNonce: rawNonce)
-
+            let credential = OAuthProvider.credential(
+                providerID: AuthProviderID.apple,  // "apple.com" 대신 AuthProviderID.apple 사용
+                idToken: tokenString,
+                rawNonce: rawNonce,
+                accessToken: nil
+            )
             Auth.auth().signIn(with: credential) { [weak self] authResult, error in
                 if let error = error {
                     print("Firebase 인증 실패: \(error.localizedDescription)")

--- a/Ting/SignUp/SignUpView/TermsModalVC.swift
+++ b/Ting/SignUp/SignUpView/TermsModalVC.swift
@@ -99,7 +99,7 @@ class TermsModalViewController: UIViewController {
     }
     
     @objc private func nextTapped() {
-        guard let presentingVC = presentingViewController else {
+        guard presentingViewController != nil else {
             print("presentingViewController가 nil입니다.")
             return
         }


### PR DESCRIPTION
## 변경사항
- OAuthProvider 경고문 삭제
- PresentingVC 변수 선언 삭제

## 주요내용
- presentingVC에서 변수를 선언했지만 사용하지 않아 Xcode에서 경고 ➡️ 여전히 값이 nil인지 확인하지만, 새 변수를 선언하지 않음.
- Firebase가 OAuth 인증 구조를 업데이트 ➡️ 명시적으로 nil 전달
- providerID가 string이 아니라 AuthProviderID 타입 필요 ➡️ AuthProviderID.apple 사용

## 스크린샷
.

## 추가계획, 고민
- 하이라키, 기타 버그 확인

Resolves: #179 