### PR TITLE
Fix: 에러처리 일부수정, 스크롤뷰 레이아웃 수정

### DIFF
--- a/Ting/Post/PostView/PostListVC.swift
+++ b/Ting/Post/PostView/PostListVC.swift
@@ -117,7 +117,8 @@ final class PostListVC: UIViewController {
                 self.postListView.collectionView.reloadData()
                 self.refreshControl.endRefreshing()
             case .failure(let error):
-                self.basicAlert(title: "서버 에러", message: "\(error.localizedDescription)")
+                print(error)
+                self.basicAlert(title: "서버 에러", message: "")
             }
             self.isLoading = false
         }
@@ -139,7 +140,8 @@ final class PostListVC: UIViewController {
                 self.hasMoreData = nextLastDocument != nil
                 self.postListView.collectionView.reloadData()
             case .failure(let error):
-                self.basicAlert(title: "서버 에러", message: "\(error.localizedDescription)")
+                print(error)
+                self.basicAlert(title: "서버 에러", message: "")
             }
             self.isLoading = false
         }

--- a/Ting/Search/SearchView/SearchView.swift
+++ b/Ting/Search/SearchView/SearchView.swift
@@ -106,6 +106,7 @@ final class SearchView: UIView {
         contentView.snp.makeConstraints {
             $0.edges.equalTo(scrollView.contentLayoutGuide)
             $0.height.equalTo(scrollView.frameLayoutGuide)
+            $0.width.equalTo(scrollView.frameLayoutGuide).priority(.low)
         }
         
         selectedCategoryStackView.snp.makeConstraints {


### PR DESCRIPTION
### 변경사항
- 에러처리 일부 수정
- 알럿에 error.localizedDescription 삭제
- 사용자에게 보여지는 것이 안좋다 하여 삭제했습니다.
- 검색필터 스크롤뷰 레이아웃 문제 수정 