### PR TITLE
Feat/Fix : DetailVC 뷰 배치 및 디자인 수정 및 조정, ReportVC 신규기능 추가 및 오류수정

### DIFF
--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -129,7 +129,7 @@ class PostDetailVC: UIViewController {
         nicknameLabel.font = .systemFont(ofSize: 14)
         nicknameLabel.textColor = .brownText
         
-        activityTimeLabel.text = "활동 가능 상태"
+        activityTimeLabel.text = "요약정보"
         activityTimeLabel.font = .systemFont(ofSize: 18, weight: .medium)
         activityTimeLabel.textColor = .deepCocoa
         
@@ -147,7 +147,7 @@ class PostDetailVC: UIViewController {
         urgencyValueLabel.textColor = .deepCocoa
         urgencyValueLabel.textAlignment = .right
         
-        techStackLabel.text = "보유 기술 스택"
+        techStackLabel.text = postType == .recruitMember ? "필요 기술 스택" : "보유 기술 스택"
         techStackLabel.font = .systemFont(ofSize: 18, weight: .medium)
         techStackLabel.textColor = .deepCocoa
         

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -22,13 +22,13 @@ class PostDetailVC: UIViewController {
     private let techStackLabel = UILabel()
     private let techStacksView = TagFlowLayout()
     private let ideaStatusLabel = UILabel()
-    private let ideaStatusView = TagFlowLayout()
+    private let ideaStatusValueLabel = UILabel()
     private let recruitsLabel = UILabel()
-    private let recruitsView = TagFlowLayout()
+    private let recruitsValueLabel = UILabel()
     private let meetingStyleLabel = UILabel()
-    private let meetingStyleView = TagFlowLayout()
+    private let meetingStyleValueLabel = UILabel()
     private let experienceLabel = UILabel()
-    private let experienceView = TagFlowLayout()
+    private let experienceValueLabel = UILabel()
     private let descriptionLabel = UILabel()
     private let descriptionTextView = UITextView()
     private let reportButton = UIButton()
@@ -133,11 +133,16 @@ class PostDetailVC: UIViewController {
         activityTimeLabel.font = .systemFont(ofSize: 18, weight: .medium)
         activityTimeLabel.textColor = .deepCocoa
         
-        urgencyLabel.text = "시급성"
+        if postType == .recruitMember {
+            urgencyLabel.text = "시급성"
+            urgencyValueLabel.text = post.urgency ?? "정보 없음"
+        } else {
+            urgencyLabel.text = "활동 가능 상태"
+            urgencyValueLabel.text = post.available ?? "정보 없음"
+        }
         urgencyLabel.font = .systemFont(ofSize: 16)
         urgencyLabel.textColor = .brownText
         
-        urgencyValueLabel.text = post.urgency ?? "정보 없음"
         urgencyValueLabel.font = .systemFont(ofSize: 16)
         urgencyValueLabel.textColor = .deepCocoa
         urgencyValueLabel.textAlignment = .right
@@ -147,20 +152,33 @@ class PostDetailVC: UIViewController {
         techStackLabel.textColor = .deepCocoa
         
         ideaStatusLabel.text = "아이디어 상황"
-        ideaStatusLabel.font = .systemFont(ofSize: 18, weight: .medium)
-        ideaStatusLabel.textColor = .deepCocoa
-
+        ideaStatusLabel.font = .systemFont(ofSize: 16)
+        ideaStatusLabel.textColor = .brownText
+        
         recruitsLabel.text = "모집인원"
-        recruitsLabel.font = .systemFont(ofSize: 18, weight: .medium)
-        recruitsLabel.textColor = .deepCocoa
-
+        recruitsLabel.font = .systemFont(ofSize: 16)
+        recruitsLabel.textColor = .brownText
+        
         meetingStyleLabel.text = "선호하는 작업방식"
-        meetingStyleLabel.font = .systemFont(ofSize: 18, weight: .medium)
-        meetingStyleLabel.textColor = .deepCocoa
-
+        meetingStyleLabel.font = .systemFont(ofSize: 16)
+        meetingStyleLabel.textColor = .brownText
+        
         experienceLabel.text = postType == .recruitMember ? "경험" : "현재 상태"
-        experienceLabel.font = .systemFont(ofSize: 18, weight: .medium)
-        experienceLabel.textColor = .deepCocoa
+        experienceLabel.font = .systemFont(ofSize: 16)
+        experienceLabel.textColor = .brownText
+        
+        // 기존 레이블들과 동일한 스타일로 설정
+        [ideaStatusValueLabel, recruitsValueLabel, meetingStyleValueLabel, experienceValueLabel].forEach { label in
+            label.font = .systemFont(ofSize: 16)
+            label.textColor = .deepCocoa
+            label.textAlignment = .right
+        }
+        
+        // 값 설정
+        ideaStatusValueLabel.text = post.ideaStatus
+        recruitsValueLabel.text = post.numberOfRecruits
+        meetingStyleValueLabel.text = post.meetingStyle
+        experienceValueLabel.text = postType == .recruitMember ? (post.experience ?? "정보 없음") : (post.currentStatus ?? "정보 없음")
         
         descriptionLabel.text = "프로젝트 설명"
         descriptionLabel.font = .systemFont(ofSize: 18, weight: .medium)
@@ -174,35 +192,26 @@ class PostDetailVC: UIViewController {
         descriptionTextView.isScrollEnabled = false
         
         DispatchQueue.main.async {
-            let topSeparator = UIView()
-            topSeparator.backgroundColor = .grayCloud
-            self.whiteCardView.addSubview(topSeparator)
+            let activitySeparator = UIView()
+            activitySeparator.backgroundColor = .grayCloud
+            self.whiteCardView.addSubview(activitySeparator)
             
-            topSeparator.snp.makeConstraints { make in
+            activitySeparator.snp.makeConstraints { make in
                 make.top.equalTo(self.activityTimeLabel.snp.top).offset(-8)
                 make.left.right.equalToSuperview().inset(20)
                 make.height.equalTo(1)
             }
-
-            [self.activityTimeLabel, self.techStackLabel, self.ideaStatusLabel,
-             self.recruitsLabel, self.meetingStyleLabel, self.experienceLabel].forEach { label in
+            
+            [self.techStackLabel, self.experienceLabel].forEach { label in
                 let separator = UIView()
                 separator.backgroundColor = .grayCloud
                 self.whiteCardView.addSubview(separator)
                 
                 separator.snp.makeConstraints { make in
-                    if label == self.activityTimeLabel {
-                        make.top.equalTo(self.urgencyLabel.snp.bottom).offset(16)
-                    } else if label == self.techStackLabel {
+                    if label == self.techStackLabel {
                         make.top.equalTo(self.techStacksView.snp.bottom).offset(16)
-                    } else if label == self.ideaStatusLabel {
-                        make.top.equalTo(self.ideaStatusView.snp.bottom).offset(16)
-                    } else if label == self.recruitsLabel {    // 추가
-                        make.top.equalTo(self.recruitsView.snp.bottom).offset(16)
-                    } else if label == self.meetingStyleLabel {
-                        make.top.equalTo(self.meetingStyleView.snp.bottom).offset(16)
-                    } else if label == self.experienceLabel {  // 추가
-                        make.top.equalTo(self.experienceView.snp.bottom).offset(16)
+                    } else if label == self.experienceLabel {
+                        make.top.equalTo(self.experienceValueLabel.snp.bottom).offset(16)
                     }
                     make.left.right.equalToSuperview().inset(20)
                     make.height.equalTo(1)
@@ -226,29 +235,6 @@ class PostDetailVC: UIViewController {
         // Tech Stack 태그 설정
         post.techStack.forEach { tag in
             techStacksView.addTag(createTagView(text: tag))
-        }
-        
-        ideaStatusView.removeAllTags()
-        ideaStatusView.addTag(createTagView(text: post.ideaStatus))
-        
-        // 모집인원 태그 설정
-        recruitsView.removeAllTags()
-        recruitsView.addTag(createTagView(text: post.numberOfRecruits))
-        
-        // 선호하는 작업방식 태그 설정
-        meetingStyleView.removeAllTags()
-        meetingStyleView.addTag(createTagView(text: post.meetingStyle))
-        
-        // 경험 또는 현재 상태 태그 설정
-        experienceView.removeAllTags()
-        if postType == .recruitMember {
-            if let experience = post.experience {
-                experienceView.addTag(createTagView(text: experience))
-            }
-        } else {
-            if let currentStatus = post.currentStatus {
-                experienceView.addTag(createTagView(text: currentStatus))
-            }
         }
     }
     
@@ -279,7 +265,7 @@ class PostDetailVC: UIViewController {
     
     private func setupButton() {
         reportButton.setTitle("신고하기", for: .normal)
-            reportButton.backgroundColor = .white
+            reportButton.backgroundColor = .background
             reportButton.layer.cornerRadius = 10
             reportButton.layer.borderColor = UIColor.accent.cgColor // 테두리 색상 추가
             reportButton.layer.borderWidth = 1.5 // 테두리 두께 추가
@@ -324,27 +310,28 @@ class PostDetailVC: UIViewController {
             titleLabel, nicknameLabel, statusTagsView, activityTimeLabel,
             urgencyLabel, urgencyValueLabel,
             techStackLabel, techStacksView,
-            ideaStatusLabel, ideaStatusView,
-            recruitsLabel, recruitsView,
-            meetingStyleLabel, meetingStyleView,
-            experienceLabel, experienceView,
-            descriptionLabel, descriptionTextView,
-            reportButton, editButton
+            ideaStatusLabel, ideaStatusValueLabel,
+            recruitsLabel, recruitsValueLabel,
+            meetingStyleLabel, meetingStyleValueLabel,
+            experienceLabel, experienceValueLabel,
+            descriptionLabel, descriptionTextView
         )
+        
+        contentView.addSubview(reportButton)
+        contentView.addSubview(editButton)
     }
     
     private func setupConstraints() {
         scrollView.snp.makeConstraints { make in
             make.edges.equalTo(view.safeAreaLayoutGuide)
         }
-        
         contentView.snp.makeConstraints { make in
             make.edges.equalTo(scrollView.contentLayoutGuide)
             make.width.equalTo(scrollView.frameLayoutGuide)
         }
         
         whiteCardView.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(16)
+            make.top.leading.trailing.equalToSuperview().inset(16)
         }
         
         titleLabel.snp.makeConstraints { make in
@@ -376,74 +363,76 @@ class PostDetailVC: UIViewController {
             make.right.equalToSuperview().inset(20)
         }
         
+        ideaStatusLabel.snp.makeConstraints { make in
+            make.top.equalTo(urgencyLabel.snp.bottom).offset(16)
+            make.left.equalToSuperview().inset(20)
+        }
+        
+        ideaStatusValueLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(ideaStatusLabel)
+            make.right.equalToSuperview().inset(20)
+        }
+        
+        recruitsLabel.snp.makeConstraints { make in
+            make.top.equalTo(ideaStatusLabel.snp.bottom).offset(16)
+            make.left.equalToSuperview().inset(20)
+        }
+        
+        recruitsValueLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(recruitsLabel)
+            make.right.equalToSuperview().inset(20)
+        }
+        
+        meetingStyleLabel.snp.makeConstraints { make in
+            make.top.equalTo(recruitsLabel.snp.bottom).offset(16)
+            make.left.equalToSuperview().inset(20)
+        }
+        
+        meetingStyleValueLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(meetingStyleLabel)
+            make.right.equalToSuperview().inset(20)
+        }
+        
+        experienceLabel.snp.makeConstraints { make in
+            make.top.equalTo(meetingStyleLabel.snp.bottom).offset(16)
+            make.left.equalToSuperview().inset(20)
+        }
+        
+        experienceValueLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(experienceLabel)
+            make.right.equalToSuperview().inset(20)
+        }
+        
         techStackLabel.snp.makeConstraints { make in
-            make.top.equalTo(urgencyLabel.snp.bottom).offset(24)
+            make.top.equalTo(experienceLabel.snp.bottom).offset(24)
             make.left.right.equalToSuperview().inset(20)
         }
         
         techStacksView.snp.makeConstraints { make in
-            make.top.equalTo(techStackLabel.snp.bottom).offset(12)
+           make.top.equalTo(techStackLabel.snp.bottom).offset(12)
             make.left.right.equalToSuperview().inset(20)
         }
         
-        ideaStatusLabel.snp.makeConstraints { make in
-            make.top.equalTo(techStacksView.snp.bottom).offset(24)
-            make.left.right.equalToSuperview().inset(20)
-        }
-
-        ideaStatusView.snp.makeConstraints { make in
-            make.top.equalTo(ideaStatusLabel.snp.bottom).offset(12)
-            make.left.right.equalToSuperview().inset(20)
-        }
-
-        recruitsLabel.snp.makeConstraints { make in
-            make.top.equalTo(ideaStatusView.snp.bottom).offset(24)
-            make.left.right.equalToSuperview().inset(20)
-        }
-
-        recruitsView.snp.makeConstraints { make in
-            make.top.equalTo(recruitsLabel.snp.bottom).offset(12)
-            make.left.right.equalToSuperview().inset(20)
-        }
-
-        meetingStyleLabel.snp.makeConstraints { make in
-            make.top.equalTo(recruitsView.snp.bottom).offset(24)
-            make.left.right.equalToSuperview().inset(20)
-        }
-
-        meetingStyleView.snp.makeConstraints { make in
-            make.top.equalTo(meetingStyleLabel.snp.bottom).offset(12)
-            make.left.right.equalToSuperview().inset(20)
-        }
-
-        experienceLabel.snp.makeConstraints { make in
-            make.top.equalTo(meetingStyleView.snp.bottom).offset(24)
-            make.left.right.equalToSuperview().inset(20)
-        }
-
-        experienceView.snp.makeConstraints { make in
-            make.top.equalTo(experienceLabel.snp.bottom).offset(12)
-            make.left.right.equalToSuperview().inset(20)
-        }
-
         descriptionLabel.snp.makeConstraints { make in
-            make.top.equalTo(experienceView.snp.bottom).offset(24)
+           make.top.equalTo(techStacksView.snp.bottom).offset(24)
             make.left.right.equalToSuperview().inset(20)
         }
         
         descriptionTextView.snp.makeConstraints { make in
             make.top.equalTo(descriptionLabel.snp.bottom).offset(12)
             make.left.right.equalToSuperview().inset(20)
-            make.bottom.equalTo(reportButton.snp.top).offset(-16)
+            make.bottom.equalToSuperview().inset(16)  // whiteCardView의 하단과의 간격
         }
-        
+       
         reportButton.snp.makeConstraints { make in
+            make.top.equalTo(whiteCardView.snp.bottom).offset(16)
             make.leading.trailing.equalToSuperview().inset(40)
             make.bottom.equalToSuperview().inset(20)
             make.height.equalTo(50)
         }
-        
+
         editButton.snp.makeConstraints { make in
+            make.top.equalTo(whiteCardView.snp.bottom).offset(16)
             make.leading.trailing.equalToSuperview().inset(40)
             make.bottom.equalToSuperview().inset(20)
             make.height.equalTo(50)

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -21,12 +21,14 @@ class PostDetailVC: UIViewController {
     private let urgencyValueLabel = UILabel()
     private let techStackLabel = UILabel()
     private let techStacksView = TagFlowLayout()
-    private let projectTypeLabel = UILabel()
-    private let projectTypeView = TagFlowLayout()
     private let ideaStatusLabel = UILabel()
     private let ideaStatusView = TagFlowLayout()
+    private let recruitsLabel = UILabel()
+    private let recruitsView = TagFlowLayout()
     private let meetingStyleLabel = UILabel()
     private let meetingStyleView = TagFlowLayout()
+    private let experienceLabel = UILabel()
+    private let experienceView = TagFlowLayout()
     private let descriptionLabel = UILabel()
     private let descriptionTextView = UITextView()
     private let reportButton = UIButton()
@@ -144,17 +146,21 @@ class PostDetailVC: UIViewController {
         techStackLabel.font = .systemFont(ofSize: 18, weight: .medium)
         techStackLabel.textColor = .deepCocoa
         
-        projectTypeLabel.text = "프로젝트 목적"
-        projectTypeLabel.font = .systemFont(ofSize: 18, weight: .medium)
-        projectTypeLabel.textColor = .deepCocoa
-        
         ideaStatusLabel.text = "아이디어 상황"
         ideaStatusLabel.font = .systemFont(ofSize: 18, weight: .medium)
         ideaStatusLabel.textColor = .deepCocoa
-        
+
+        recruitsLabel.text = "모집인원"
+        recruitsLabel.font = .systemFont(ofSize: 18, weight: .medium)
+        recruitsLabel.textColor = .deepCocoa
+
         meetingStyleLabel.text = "선호하는 작업방식"
         meetingStyleLabel.font = .systemFont(ofSize: 18, weight: .medium)
         meetingStyleLabel.textColor = .deepCocoa
+
+        experienceLabel.text = "경험"
+        experienceLabel.font = .systemFont(ofSize: 18, weight: .medium)
+        experienceLabel.textColor = .deepCocoa
         
         descriptionLabel.text = "프로젝트 설명"
         descriptionLabel.font = .systemFont(ofSize: 18, weight: .medium)
@@ -178,8 +184,8 @@ class PostDetailVC: UIViewController {
                 make.height.equalTo(1)
             }
 
-            [self.activityTimeLabel, self.techStackLabel, self.projectTypeLabel,
-             self.ideaStatusLabel, self.meetingStyleLabel].forEach { label in
+            [self.activityTimeLabel, self.techStackLabel, self.ideaStatusLabel,
+             self.recruitsLabel, self.meetingStyleLabel, self.experienceLabel].forEach { label in
                 let separator = UIView()
                 separator.backgroundColor = .grayCloud
                 self.whiteCardView.addSubview(separator)
@@ -189,12 +195,14 @@ class PostDetailVC: UIViewController {
                         make.top.equalTo(self.urgencyLabel.snp.bottom).offset(16)
                     } else if label == self.techStackLabel {
                         make.top.equalTo(self.techStacksView.snp.bottom).offset(16)
-                    } else if label == self.projectTypeLabel {
-                        make.top.equalTo(self.projectTypeView.snp.bottom).offset(16)
                     } else if label == self.ideaStatusLabel {
                         make.top.equalTo(self.ideaStatusView.snp.bottom).offset(16)
+                    } else if label == self.recruitsLabel {    // 추가
+                        make.top.equalTo(self.recruitsView.snp.bottom).offset(16)
                     } else if label == self.meetingStyleLabel {
                         make.top.equalTo(self.meetingStyleView.snp.bottom).offset(16)
+                    } else if label == self.experienceLabel {  // 추가
+                        make.top.equalTo(self.experienceView.snp.bottom).offset(16)
                     }
                     make.left.right.equalToSuperview().inset(20)
                     make.height.equalTo(1)
@@ -209,7 +217,6 @@ class PostDetailVC: UIViewController {
         // 기존 태그들 모두 제거
         statusTagsView.removeAllTags()
         techStacksView.removeAllTags()
-        projectTypeView.removeAllTags()
         
         // Position 태그 설정
         post.position.forEach { tag in
@@ -221,17 +228,21 @@ class PostDetailVC: UIViewController {
             techStacksView.addTag(createTagView(text: tag))
         }
         
-        // 아이디어 상황 태그 설정
         ideaStatusView.removeAllTags()
         ideaStatusView.addTag(createTagView(text: post.ideaStatus))
+        
+        // 모집인원 태그 설정
+        recruitsView.removeAllTags()
+        recruitsView.addTag(createTagView(text: post.numberOfRecruits))
         
         // 선호하는 작업방식 태그 설정
         meetingStyleView.removeAllTags()
         meetingStyleView.addTag(createTagView(text: post.meetingStyle))
         
-        // 프로젝트 타입 태그 설정
-        [post.ideaStatus, post.meetingStyle].forEach { tag in
-            projectTypeView.addTag(createTagView(text: tag))
+        // 경험 태그 설정
+        experienceView.removeAllTags()
+        if let experience = post.experience {
+            experienceView.addTag(createTagView(text: experience))
         }
     }
     
@@ -304,12 +315,13 @@ class PostDetailVC: UIViewController {
         contentView.addSubview(whiteCardView)
         
         whiteCardView.addSubviews(
-            titleLabel, nicknameLabel,statusTagsView, activityTimeLabel,
+            titleLabel, nicknameLabel, statusTagsView, activityTimeLabel,
             urgencyLabel, urgencyValueLabel,
             techStackLabel, techStacksView,
-            projectTypeLabel, projectTypeView,
             ideaStatusLabel, ideaStatusView,
+            recruitsLabel, recruitsView,
             meetingStyleLabel, meetingStyleView,
+            experienceLabel, experienceView,
             descriptionLabel, descriptionTextView,
             reportButton, editButton
         )
@@ -368,39 +380,48 @@ class PostDetailVC: UIViewController {
             make.left.right.equalToSuperview().inset(20)
         }
         
-        projectTypeLabel.snp.makeConstraints { make in
+        ideaStatusLabel.snp.makeConstraints { make in
             make.top.equalTo(techStacksView.snp.bottom).offset(24)
             make.left.right.equalToSuperview().inset(20)
         }
-        
-        projectTypeView.snp.makeConstraints { make in
-            make.top.equalTo(projectTypeLabel.snp.bottom).offset(12)
-            make.left.right.equalToSuperview().inset(20)
-        }
-        
-        // 새로운 섹션들의 제약조건
-        ideaStatusLabel.snp.makeConstraints { make in
-            make.top.equalTo(projectTypeView.snp.bottom).offset(24)
-            make.left.right.equalToSuperview().inset(20)
-        }
-        
+
         ideaStatusView.snp.makeConstraints { make in
             make.top.equalTo(ideaStatusLabel.snp.bottom).offset(12)
             make.left.right.equalToSuperview().inset(20)
         }
-        
-        meetingStyleLabel.snp.makeConstraints { make in
+
+        recruitsLabel.snp.makeConstraints { make in
             make.top.equalTo(ideaStatusView.snp.bottom).offset(24)
             make.left.right.equalToSuperview().inset(20)
         }
-        
+
+        recruitsView.snp.makeConstraints { make in
+            make.top.equalTo(recruitsLabel.snp.bottom).offset(12)
+            make.left.right.equalToSuperview().inset(20)
+        }
+
+        meetingStyleLabel.snp.makeConstraints { make in
+            make.top.equalTo(recruitsView.snp.bottom).offset(24)
+            make.left.right.equalToSuperview().inset(20)
+        }
+
         meetingStyleView.snp.makeConstraints { make in
             make.top.equalTo(meetingStyleLabel.snp.bottom).offset(12)
             make.left.right.equalToSuperview().inset(20)
         }
-        
-        descriptionLabel.snp.makeConstraints { make in
+
+        experienceLabel.snp.makeConstraints { make in
             make.top.equalTo(meetingStyleView.snp.bottom).offset(24)
+            make.left.right.equalToSuperview().inset(20)
+        }
+
+        experienceView.snp.makeConstraints { make in
+            make.top.equalTo(experienceLabel.snp.bottom).offset(12)
+            make.left.right.equalToSuperview().inset(20)
+        }
+
+        descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(experienceView.snp.bottom).offset(24)
             make.left.right.equalToSuperview().inset(20)
         }
         

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -14,6 +14,7 @@ class PostDetailVC: UIViewController {
     private let contentView = UIView()
     private let whiteCardView = UIView()
     private let titleLabel = UILabel()
+    private let nicknameLabel = UILabel()
     private let statusTagsView = TagFlowLayout()
     private let activityTimeLabel = UILabel()
     private let urgencyLabel = UILabel()
@@ -22,6 +23,10 @@ class PostDetailVC: UIViewController {
     private let techStacksView = TagFlowLayout()
     private let projectTypeLabel = UILabel()
     private let projectTypeView = TagFlowLayout()
+    private let ideaStatusLabel = UILabel()
+    private let ideaStatusView = TagFlowLayout()
+    private let meetingStyleLabel = UILabel()
+    private let meetingStyleView = TagFlowLayout()
     private let descriptionLabel = UILabel()
     private let descriptionTextView = UITextView()
     private let reportButton = UIButton()
@@ -115,6 +120,12 @@ class PostDetailVC: UIViewController {
         titleLabel.text = post.title
         titleLabel.font = .systemFont(ofSize: 24, weight: .bold)
         titleLabel.textColor = .deepCocoa
+        titleLabel.numberOfLines = 0                // 여러 줄 표시 설정
+        titleLabel.lineBreakMode = .byWordWrapping  // 단어 단위로 줄바꿈
+        
+        nicknameLabel.text = "작성자: \(post.nickName)"
+        nicknameLabel.font = .systemFont(ofSize: 14)
+        nicknameLabel.textColor = .brownText
         
         activityTimeLabel.text = "활동 가능 상태"
         activityTimeLabel.font = .systemFont(ofSize: 18, weight: .medium)
@@ -137,6 +148,14 @@ class PostDetailVC: UIViewController {
         projectTypeLabel.font = .systemFont(ofSize: 18, weight: .medium)
         projectTypeLabel.textColor = .deepCocoa
         
+        ideaStatusLabel.text = "아이디어 상황"
+        ideaStatusLabel.font = .systemFont(ofSize: 18, weight: .medium)
+        ideaStatusLabel.textColor = .deepCocoa
+        
+        meetingStyleLabel.text = "선호하는 작업방식"
+        meetingStyleLabel.font = .systemFont(ofSize: 18, weight: .medium)
+        meetingStyleLabel.textColor = .deepCocoa
+        
         descriptionLabel.text = "프로젝트 설명"
         descriptionLabel.font = .systemFont(ofSize: 18, weight: .medium)
         descriptionLabel.textColor = .deepCocoa
@@ -149,18 +168,18 @@ class PostDetailVC: UIViewController {
         descriptionTextView.isScrollEnabled = false
         
         DispatchQueue.main.async {
-            // 활동가능상태 위에 구분선 추가
-            let statusSeparator = UIView()
-            statusSeparator.backgroundColor = .grayCloud
-            self.whiteCardView.addSubview(statusSeparator)
+            let topSeparator = UIView()
+            topSeparator.backgroundColor = .grayCloud
+            self.whiteCardView.addSubview(topSeparator)
             
-            statusSeparator.snp.makeConstraints { make in
+            topSeparator.snp.makeConstraints { make in
                 make.top.equalTo(self.activityTimeLabel.snp.top).offset(-8)
                 make.left.right.equalToSuperview().inset(20)
                 make.height.equalTo(1)
             }
-            //구분선들
-            [self.activityTimeLabel, self.techStackLabel, self.projectTypeLabel,].forEach { label in
+
+            [self.activityTimeLabel, self.techStackLabel, self.projectTypeLabel,
+             self.ideaStatusLabel, self.meetingStyleLabel].forEach { label in
                 let separator = UIView()
                 separator.backgroundColor = .grayCloud
                 self.whiteCardView.addSubview(separator)
@@ -172,6 +191,10 @@ class PostDetailVC: UIViewController {
                         make.top.equalTo(self.techStacksView.snp.bottom).offset(16)
                     } else if label == self.projectTypeLabel {
                         make.top.equalTo(self.projectTypeView.snp.bottom).offset(16)
+                    } else if label == self.ideaStatusLabel {
+                        make.top.equalTo(self.ideaStatusView.snp.bottom).offset(16)
+                    } else if label == self.meetingStyleLabel {
+                        make.top.equalTo(self.meetingStyleView.snp.bottom).offset(16)
                     }
                     make.left.right.equalToSuperview().inset(20)
                     make.height.equalTo(1)
@@ -197,6 +220,14 @@ class PostDetailVC: UIViewController {
         post.techStack.forEach { tag in
             techStacksView.addTag(createTagView(text: tag))
         }
+        
+        // 아이디어 상황 태그 설정
+        ideaStatusView.removeAllTags()
+        ideaStatusView.addTag(createTagView(text: post.ideaStatus))
+        
+        // 선호하는 작업방식 태그 설정
+        meetingStyleView.removeAllTags()
+        meetingStyleView.addTag(createTagView(text: post.meetingStyle))
         
         // 프로젝트 타입 태그 설정
         [post.ideaStatus, post.meetingStyle].forEach { tag in
@@ -273,10 +304,12 @@ class PostDetailVC: UIViewController {
         contentView.addSubview(whiteCardView)
         
         whiteCardView.addSubviews(
-            titleLabel, statusTagsView, activityTimeLabel,
+            titleLabel, nicknameLabel,statusTagsView, activityTimeLabel,
             urgencyLabel, urgencyValueLabel,
             techStackLabel, techStacksView,
             projectTypeLabel, projectTypeView,
+            ideaStatusLabel, ideaStatusView,
+            meetingStyleLabel, meetingStyleView,
             descriptionLabel, descriptionTextView,
             reportButton, editButton
         )
@@ -300,8 +333,13 @@ class PostDetailVC: UIViewController {
             make.top.left.right.equalToSuperview().inset(20)
         }
         
+        nicknameLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(8)
+            make.left.right.equalToSuperview().inset(20)
+        }
+        
         statusTagsView.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(16)
+            make.top.equalTo(nicknameLabel.snp.bottom).offset(12)
             make.left.right.equalToSuperview().inset(20)
         }
         
@@ -340,8 +378,29 @@ class PostDetailVC: UIViewController {
             make.left.right.equalToSuperview().inset(20)
         }
         
-        descriptionLabel.snp.makeConstraints { make in
+        // 새로운 섹션들의 제약조건
+        ideaStatusLabel.snp.makeConstraints { make in
             make.top.equalTo(projectTypeView.snp.bottom).offset(24)
+            make.left.right.equalToSuperview().inset(20)
+        }
+        
+        ideaStatusView.snp.makeConstraints { make in
+            make.top.equalTo(ideaStatusLabel.snp.bottom).offset(12)
+            make.left.right.equalToSuperview().inset(20)
+        }
+        
+        meetingStyleLabel.snp.makeConstraints { make in
+            make.top.equalTo(ideaStatusView.snp.bottom).offset(24)
+            make.left.right.equalToSuperview().inset(20)
+        }
+        
+        meetingStyleView.snp.makeConstraints { make in
+            make.top.equalTo(meetingStyleLabel.snp.bottom).offset(12)
+            make.left.right.equalToSuperview().inset(20)
+        }
+        
+        descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(meetingStyleView.snp.bottom).offset(24)
             make.left.right.equalToSuperview().inset(20)
         }
         

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -158,7 +158,7 @@ class PostDetailVC: UIViewController {
         meetingStyleLabel.font = .systemFont(ofSize: 18, weight: .medium)
         meetingStyleLabel.textColor = .deepCocoa
 
-        experienceLabel.text = "경험"
+        experienceLabel.text = postType == .recruitMember ? "경험" : "현재 상태"
         experienceLabel.font = .systemFont(ofSize: 18, weight: .medium)
         experienceLabel.textColor = .deepCocoa
         
@@ -239,10 +239,16 @@ class PostDetailVC: UIViewController {
         meetingStyleView.removeAllTags()
         meetingStyleView.addTag(createTagView(text: post.meetingStyle))
         
-        // 경험 태그 설정
+        // 경험 또는 현재 상태 태그 설정
         experienceView.removeAllTags()
-        if let experience = post.experience {
-            experienceView.addTag(createTagView(text: experience))
+        if postType == .recruitMember {
+            if let experience = post.experience {
+                experienceView.addTag(createTagView(text: experience))
+            }
+        } else {
+            if let currentStatus = post.currentStatus {
+                experienceView.addTag(createTagView(text: currentStatus))
+            }
         }
     }
     

--- a/Ting/Post/PostView/ReportVC.swift
+++ b/Ting/Post/PostView/ReportVC.swift
@@ -125,6 +125,8 @@ class ReportVC: UIViewController, UITextViewDelegate {
         postTitleValueLabel.font = .systemFont(ofSize: 16)
         postTitleValueLabel.textColor = .deepCocoa
         postTitleValueLabel.textAlignment = .right
+        postTitleValueLabel.numberOfLines = 0               // 여러 줄 표시 허용
+        postTitleValueLabel.lineBreakMode = .byWordWrapping // 단어 단위로 줄바꿈
         
         authorLabel.text = "작성자"
         authorLabel.font = .systemFont(ofSize: 16)
@@ -272,14 +274,15 @@ class ReportVC: UIViewController, UITextViewDelegate {
             make.top.equalToSuperview().offset(16)
             make.left.equalToSuperview().offset(16)
         }
-        
+
         postTitleValueLabel.snp.makeConstraints { make in
-            make.centerY.equalTo(postTitleLabel)
+            make.top.equalTo(postTitleLabel)
+            make.left.equalTo(postTitleLabel.snp.right).offset(16)
             make.right.equalToSuperview().offset(-16)
         }
-        
+
         authorLabel.snp.makeConstraints { make in
-            make.top.equalTo(postTitleLabel.snp.bottom).offset(16)
+            make.top.equalTo(postTitleValueLabel.snp.bottom).offset(16)
             make.left.equalToSuperview().offset(16)
         }
         

--- a/Ting/Post/PostView/ReportVC.swift
+++ b/Ting/Post/PostView/ReportVC.swift
@@ -168,19 +168,13 @@ class ReportVC: UIViewController, UITextViewDelegate {
     
     private static func createRadioButton() -> UIButton {
         let button = UIButton()
-        
-        // 버튼 구성 생성
-        var config = UIButton.Configuration.plain()
-        config.contentInsets = NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 2, trailing: 2)
-        config.imagePlacement = .all  // 이미지만 표시
-        config.background.backgroundColor = .white
-        
-        button.configuration = config
         button.layer.borderWidth = 2
         button.layer.cornerRadius = 10
         button.layer.borderColor = UIColor.grayCloud.cgColor
+        button.backgroundColor = .white
         button.contentMode = .center
-        
+        button.imageView?.contentMode = .scaleAspectFit
+        button.imageEdgeInsets = UIEdgeInsets(top: 2, left: 2, bottom: 2, right: 2)
         return button
     }
     


### PR DESCRIPTION
# 변경사항
- DetailVC 데이터 출력을 위한 뷰 디자인 및 각 영역 배치 수정 작업
- ReportVC 데이터 출력을 위한 뷰 수정 및 오류수정

# 주요내용

## DetailVC

### Feat 
- 뷰 출력수정 및 배치수정
   - 제목 길어질 시 자동으로 아랫줄로 줄변경 기능 추가
   - 제목 하단의 작성자 닉네임 출력
   - UploadVC에서 값은 받지만 미출력하던 내용들 출력
   - UploadVC에서 받은 값에 따라 출력하는 내용, 라벨 다르게 수정
   - 기술스택, 제목 하단 태그 제외 부분들은 중간에 라벨 - 텍스트 순으로 출력되게 정렬
   - 카드뷰 밖으로 신고/편집하기 버튼 출력


## ReportVC

### Feat
- 신고 게시글 제목이 길어질 시 자동으로 아랫줄로 늘어나게 수정

### Fix
- 라디오 버튼 수정전 기존코드로 원복
   - 중복체크 되던 현상 해결
   - 이상하게 출력되던 현상 수정

## 스크린샷
<img width="240" alt="Simulator Screenshot - iPhone 16 Pro - 2025-02-12 at 23 10 05" src="https://github.com/user-attachments/assets/24a5e748-16d8-4ee3-9952-81740f10f451" />

<img width="240" alt="Simulator Screenshot - iPhone 16 Pro - 2025-02-12 at 23 10 09" src="https://github.com/user-attachments/assets/13fdeabe-0747-47f4-9bfc-d5c2330ecb60" />

<img width="240" alt="Simulator Screenshot - iPhone 16 Pro - 2025-02-12 at 23 10 19" src="https://github.com/user-attachments/assets/82226c6c-8768-4dcf-95cc-ef8223c7dbfc" />



Resolves : #191 