### PR TITLE
Fix : DetailVC 뷰 객체 추가 및 조정

### DIFF
--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -30,6 +30,8 @@ class PostDetailVC: UIViewController {
     private let meetingStyleValueLabel = UILabel()
     private let experienceLabel = UILabel()
     private let experienceValueLabel = UILabel()
+    private let positionLabel = UILabel()
+    private let positionTagsView = TagFlowLayout()
     private let descriptionLabel = UILabel()
     private let descriptionTextView = UITextView()
     private let reportButton = UIButton()
@@ -95,6 +97,25 @@ class PostDetailVC: UIViewController {
         setupBasic()
         setupComponents()
         setupConstraints()
+        
+        // Position 관련 UI visibility 설정과 constraint 조정
+        if postType == .recruitMember {
+            positionLabel.isHidden = false
+            positionTagsView.isHidden = false
+            
+            descriptionLabel.snp.remakeConstraints { make in
+                make.top.equalTo(positionTagsView.snp.bottom).offset(24)
+                make.left.right.equalToSuperview().inset(20)
+            }
+        } else {
+            positionLabel.isHidden = true
+            positionTagsView.isHidden = true
+            
+            descriptionLabel.snp.remakeConstraints { make in
+                make.top.equalTo(techStacksView.snp.bottom).offset(24)
+                make.left.right.equalToSuperview().inset(20)
+            }
+        }
     }
     
     private func setupBasic() {
@@ -167,6 +188,10 @@ class PostDetailVC: UIViewController {
         experienceLabel.font = .systemFont(ofSize: 16)
         experienceLabel.textColor = .brownText
         
+        positionLabel.text = "필요한 직무"
+        positionLabel.font = .systemFont(ofSize: 18, weight: .medium)
+        positionLabel.textColor = .deepCocoa
+        
         // 기존 레이블들과 동일한 스타일로 설정
         [ideaStatusValueLabel, recruitsValueLabel, meetingStyleValueLabel, experienceValueLabel].forEach { label in
             label.font = .systemFont(ofSize: 16)
@@ -191,6 +216,7 @@ class PostDetailVC: UIViewController {
         descriptionTextView.backgroundColor = .clear
         descriptionTextView.isScrollEnabled = false
         
+        // 구별선
         DispatchQueue.main.async {
             let activitySeparator = UIView()
             activitySeparator.backgroundColor = .grayCloud
@@ -202,7 +228,12 @@ class PostDetailVC: UIViewController {
                 make.height.equalTo(1)
             }
             
-            [self.techStackLabel, self.experienceLabel].forEach { label in
+            // postType에 따라 다른 배열을 사용
+            let separatorLabels = self.postType == .recruitMember ?
+                [self.techStackLabel, self.experienceLabel, self.positionLabel] :
+                [self.techStackLabel, self.experienceLabel]
+            
+            separatorLabels.forEach { label in
                 let separator = UIView()
                 separator.backgroundColor = .grayCloud
                 self.whiteCardView.addSubview(separator)
@@ -212,6 +243,8 @@ class PostDetailVC: UIViewController {
                         make.top.equalTo(self.techStacksView.snp.bottom).offset(16)
                     } else if label == self.experienceLabel {
                         make.top.equalTo(self.experienceValueLabel.snp.bottom).offset(16)
+                    } else if label == self.positionLabel {
+                        make.top.equalTo(self.positionTagsView.snp.bottom).offset(16)
                     }
                     make.left.right.equalToSuperview().inset(20)
                     make.height.equalTo(1)
@@ -245,6 +278,13 @@ class PostDetailVC: UIViewController {
         // Tech Stack 태그 설정
         post.techStack.forEach { tag in
             techStacksView.addTag(createTagView(text: tag))
+        }
+        
+        // Position 태그 설정 (팀원 모집인 경우에만)
+        if postType == .recruitMember {
+            post.position.forEach { tag in
+                positionTagsView.addTag(createTagView(text: tag))
+            }
         }
     }
     
@@ -324,6 +364,7 @@ class PostDetailVC: UIViewController {
             recruitsLabel, recruitsValueLabel,
             meetingStyleLabel, meetingStyleValueLabel,
             experienceLabel, experienceValueLabel,
+            positionLabel, positionTagsView,
             descriptionLabel, descriptionTextView
         )
         
@@ -419,12 +460,23 @@ class PostDetailVC: UIViewController {
         }
         
         techStacksView.snp.makeConstraints { make in
-           make.top.equalTo(techStackLabel.snp.bottom).offset(12)
+            make.top.equalTo(techStackLabel.snp.bottom).offset(12)
+            make.left.right.equalToSuperview().inset(20)
+        }
+        
+        // Position 레이블과 태그뷰 제약조건 추가
+        positionLabel.snp.makeConstraints { make in
+            make.top.equalTo(techStacksView.snp.bottom).offset(24)
+            make.left.right.equalToSuperview().inset(20)
+        }
+        
+        positionTagsView.snp.makeConstraints { make in
+            make.top.equalTo(positionLabel.snp.bottom).offset(12)
             make.left.right.equalToSuperview().inset(20)
         }
         
         descriptionLabel.snp.makeConstraints { make in
-           make.top.equalTo(techStacksView.snp.bottom).offset(24)
+            make.top.equalTo(positionTagsView.snp.bottom).offset(24)
             make.left.right.equalToSuperview().inset(20)
         }
         

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -98,18 +98,44 @@ class PostDetailVC: UIViewController {
         setupComponents()
         setupConstraints()
         
-        // Position 관련 UI visibility 설정과 constraint 조정
+        // Position 관련 UI visibility 및 높이 조절
         if postType == .recruitMember {
             positionLabel.isHidden = false
             positionTagsView.isHidden = false
             
-            descriptionLabel.snp.remakeConstraints { make in
+            // 팀원 모집일 때는 정상적인 높이 설정
+            positionLabel.snp.updateConstraints { make in
+                make.height.equalTo(24) // 라벨 실제 높이
+            }
+            positionTagsView.snp.updateConstraints { make in
+                make.height.equalTo(40) // 태그뷰 예상 높이
+            }
+            
+            // 상단 여백도 정상 설정
+            techStackLabel.snp.updateConstraints { make in
                 make.top.equalTo(positionTagsView.snp.bottom).offset(24)
+            }
+            
+            descriptionLabel.snp.remakeConstraints { make in
+                make.top.equalTo(techStacksView.snp.bottom).offset(24)
                 make.left.right.equalToSuperview().inset(20)
             }
         } else {
             positionLabel.isHidden = true
             positionTagsView.isHidden = true
+            
+            // 팀 합류일 때는 높이를 0으로 설정
+            positionLabel.snp.updateConstraints { make in
+                make.height.equalTo(0)
+            }
+            positionTagsView.snp.updateConstraints { make in
+                make.height.equalTo(0)
+            }
+            
+            // 상단 여백도 0으로 설정
+            techStackLabel.snp.updateConstraints { make in
+                make.top.equalTo(positionTagsView.snp.bottom).offset(0)
+            }
             
             descriptionLabel.snp.remakeConstraints { make in
                 make.top.equalTo(techStacksView.snp.bottom).offset(24)
@@ -230,8 +256,8 @@ class PostDetailVC: UIViewController {
             
             // postType에 따라 다른 배열을 사용
             let separatorLabels = self.postType == .recruitMember ?
-                [self.techStackLabel, self.experienceLabel, self.positionLabel] :
-                [self.techStackLabel, self.experienceLabel]
+            [self.positionLabel, self.techStackLabel, self.experienceLabel] :
+            [self.techStackLabel, self.experienceLabel]
             
             separatorLabels.forEach { label in
                 let separator = UIView()
@@ -239,12 +265,12 @@ class PostDetailVC: UIViewController {
                 self.whiteCardView.addSubview(separator)
                 
                 separator.snp.makeConstraints { make in
-                    if label == self.techStackLabel {
+                    if label == self.positionLabel {
+                        make.top.equalTo(self.positionTagsView.snp.bottom).offset(16)
+                    } else if label == self.techStackLabel {
                         make.top.equalTo(self.techStacksView.snp.bottom).offset(16)
                     } else if label == self.experienceLabel {
                         make.top.equalTo(self.experienceValueLabel.snp.bottom).offset(16)
-                    } else if label == self.positionLabel {
-                        make.top.equalTo(self.positionTagsView.snp.bottom).offset(16)
                     }
                     make.left.right.equalToSuperview().inset(20)
                     make.height.equalTo(1)
@@ -454,8 +480,20 @@ class PostDetailVC: UIViewController {
             make.right.equalToSuperview().inset(20)
         }
         
-        techStackLabel.snp.makeConstraints { make in
+        positionLabel.snp.makeConstraints { make in
             make.top.equalTo(experienceLabel.snp.bottom).offset(24)
+            make.left.right.equalToSuperview().inset(20)
+            make.height.equalTo(24) // 초기 높이 설정
+        }
+        
+        positionTagsView.snp.makeConstraints { make in
+            make.top.equalTo(positionLabel.snp.bottom).offset(12)
+            make.left.right.equalToSuperview().inset(20)
+            make.height.equalTo(40) // 초기 높이 설정
+        }
+        
+        techStackLabel.snp.makeConstraints { make in
+            make.top.equalTo(positionTagsView.snp.bottom).offset(24)
             make.left.right.equalToSuperview().inset(20)
         }
         
@@ -464,19 +502,8 @@ class PostDetailVC: UIViewController {
             make.left.right.equalToSuperview().inset(20)
         }
         
-        // Position 레이블과 태그뷰 제약조건 추가
-        positionLabel.snp.makeConstraints { make in
-            make.top.equalTo(techStacksView.snp.bottom).offset(24)
-            make.left.right.equalToSuperview().inset(20)
-        }
-        
-        positionTagsView.snp.makeConstraints { make in
-            make.top.equalTo(positionLabel.snp.bottom).offset(12)
-            make.left.right.equalToSuperview().inset(20)
-        }
-        
         descriptionLabel.snp.makeConstraints { make in
-            make.top.equalTo(positionTagsView.snp.bottom).offset(24)
+            make.top.equalTo(techStacksView.snp.bottom).offset(24)
             make.left.right.equalToSuperview().inset(20)
         }
         

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -112,7 +112,6 @@ class PostDetailVC: UIViewController {
     
     private func setupComponents() {
         setupLabels()
-        setupTags()
         setupButton()
         addSubviews()
     }
@@ -228,37 +227,22 @@ class PostDetailVC: UIViewController {
         statusTagsView.removeAllTags()
         techStacksView.removeAllTags()
         
-        // UserInfo에서 role 정보 가져오기
-        UserInfoService.shared.fetchUserInfo { [weak self] result in
-            guard let self = self else { return }
-            
-            switch result {
-            case .success(let userInfo):
-                if post.nickName == userInfo.nickName {
-                    // 현재 사용자의 게시글인 경우 해당 role을 태그로 표시
+        // 게시글 작성자의 role 정보 가져오기
+        let db = Firestore.firestore()
+        db.collection("infos")
+            .whereField("nickName", isEqualTo: post.nickName)
+            .getDocuments { [weak self] snapshot, error in
+                guard let self = self else { return }
+                
+                if let document = snapshot?.documents.first,
+                   let userInfo = try? document.data(as: UserInfo.self) {
                     DispatchQueue.main.async {
                         self.statusTagsView.addTag(self.createTagView(text: userInfo.role))
                     }
-                } else {
-                    // 다른 사용자의 게시글인 경우, infos 컬렉션에서 해당 닉네임의 role 찾기
-                    let db = Firestore.firestore()
-                    db.collection("infos")
-                        .whereField("nickName", isEqualTo: post.nickName)
-                        .getDocuments { snapshot, error in
-                            if let document = snapshot?.documents.first,
-                               let userInfo = try? document.data(as: UserInfo.self) {
-                                DispatchQueue.main.async {
-                                    self.statusTagsView.addTag(self.createTagView(text: userInfo.role))
-                                }
-                            }
-                        }
                 }
-            case .failure(let error):
-                print("Error fetching user info: \(error)")
             }
-        }
         
-        // Tech Stack 태그 설정 (기존 코드 유지)
+        // Tech Stack 태그 설정
         post.techStack.forEach { tag in
             techStacksView.addTag(createTagView(text: tag))
         }

--- a/Ting/Post/PostView/PostListVC.swift
+++ b/Ting/Post/PostView/PostListVC.swift
@@ -165,32 +165,21 @@ extension PostListVC: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        // 메인뷰 카드모양 재사용
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainViewCell.identifier, for: indexPath) as? MainViewCell else {
             return UICollectionViewCell()
         }
         let post = postList[indexPath.row]
         let date = post.createdAt
         let formattedDate = DateFormatter.postDateFormatter.string(from: date)
-        
-        // 게시글 작성자의 role 정보 가져오기
-        let db = Firestore.firestore()
-        db.collection("infos")
-            .whereField("nickName", isEqualTo: post.nickName)
-            .getDocuments { [weak cell] snapshot, error in
-                if let document = snapshot?.documents.first,
-                   let userInfo = try? document.data(as: UserInfo.self) {
-                    DispatchQueue.main.async {
-                        cell?.configure(
-                            with: post.title,
-                            detail: post.detail,
-                            nickName: post.nickName,
-                            date: formattedDate,
-                            tags: [userInfo.role]
-                        )
-                    }
-                }
-            }
-        
+        cell.configure(
+            with: post.title,
+            detail: post.detail,
+            nickName: post.nickName,
+            date: formattedDate,
+            tags: post.position
+        )
+        /// TODO - Rx 적용, 서버에서 받아온 데이터로 셀 적용
         return cell
     }
     


### PR DESCRIPTION
## 변경사항
- DetailVC 파일 수정


## 주요내용

### DetailVC
- 제목 하단 태그 포지션 출력
   - 태그 중복출력 해결
- 모집/합류에 따라서 필요한 직무 출력 조정
- 모집/합류에 따라서 필요 기술 스택/ 보유 기술 스택 출력값 구분


<img width="400" alt="Simulator Screenshot - iPhone 16 Pro - 2025-02-13 at 11 21 07" src="https://github.com/user-attachments/assets/74d68b74-8059-4730-9097-5f759739d63d" />

<img width="400" alt="Simulator Screenshot - iPhone 16 Pro - 2025-02-13 at 11 21 15" src="https://github.com/user-attachments/assets/88be5b02-bed0-453a-80cc-cfb1043fa16d" />



