### PR TITLE
Feat : ReportVC 신고하기 버튼 시 infos에 신고데이터 배열 업데이트

### DIFF
--- a/Ting/Models/UserInfo.swift
+++ b/Ting/Models/UserInfo.swift
@@ -20,5 +20,6 @@ struct UserInfo: Identifiable, Codable {
     let workStyle: String
     let location: String
     let interest: String
+    var reportedPosts: [String]? // 신고한 게시글 ID 목록
 }
 


### PR DESCRIPTION
## 변경사항
- UserInfoService, UserInfo, ReportVC 파일 수정

## 주요내용
- ReportVC에서 신고하기 버튼 터치 시 infos에 신고 게시글 id 배열로 저장

## 추가계획, 고민
- 신고하기 중첩 누적시 자동 삭제기능?
- 신고하기 여러번 적용된 사용자는 기능제한? 벤? 기능 구현

Resolves: #206 