### PR TITLE
Feat : 신고하기 버튼 터치 시 해당 게시글의 신고하기 횟수 증가 및 5회인 경우에 해당 게시글은 자동 삭제

### DIFF
--- a/Ting/Models/Post.swift
+++ b/Ting/Models/Post.swift
@@ -23,6 +23,7 @@ struct Post: Identifiable, Codable {
     let meetingStyle: String  // 선호하는 작업 방식
     let numberOfRecruits: String  // 모집 인원
     let createdAt: Date  // Firestore Timestamp와 자동 변환
+    var reportCount: Int? = 0 // 신고 횟수
     
     // 팀원 모집 전용 필드 (옵셔널)
     var urgency: String? // 시급성 - "급함", "보통", "여유로움"

--- a/Ting/Post/PostView/JoinTeamUploadVC.swift
+++ b/Ting/Post/PostView/JoinTeamUploadVC.swift
@@ -98,6 +98,7 @@ final class JoinTeamUploadVC: UIViewController {
                     meetingStyle: selectedMeetingStyle,
                     numberOfRecruits: selectedTeamSize,
                     createdAt: Date(),
+                    reportCount: 0,  // 초기 신고 카운트는 0으로 설정
                     urgency: nil,
                     experience: nil,
                     available: selectedAvailable,

--- a/Ting/Post/PostView/RecruitMemberUploadVC.swift
+++ b/Ting/Post/PostView/RecruitMemberUploadVC.swift
@@ -102,6 +102,7 @@ final class RecruitMemberUploadVC: UIViewController {
                     meetingStyle: selectedMeetingStyle,
                     numberOfRecruits: selectedRecruits,
                     createdAt: Date(),
+                    reportCount: 0,  // 초기 신고 카운트는 0으로 설정
                     urgency: selectedUrgency,
                     experience: selectedExperience,
                     available: nil,

--- a/Ting/Post/PostView/ReportVC.swift
+++ b/Ting/Post/PostView/ReportVC.swift
@@ -411,9 +411,6 @@ class ReportVC: UIViewController, UITextViewDelegate {
             return
         }
         
-        // 디버깅을 위한 로그
-        print("Checking if post \(postId) has been reported")
-        
         // 1. 먼저 중복 신고 여부 확인
         UserInfoService.shared.hasReportedPost(postId: postId) { [weak self] result in
             guard let self = self else { return }
@@ -442,26 +439,32 @@ class ReportVC: UIViewController, UITextViewDelegate {
                 ReportManager.shared.uploadReport(report) { [weak self] result in
                     switch result {
                     case .success:
-                        print("Successfully uploaded report for post: \(postId)")
-                        
-                        // 3. Report 저장 성공 시에만 UserInfo 업데이트
-                        UserInfoService.shared.addReportedPost(postId: postId) { result in
-                            DispatchQueue.main.async {
-                                switch result {
-                                case .success:
-                                    print("Successfully added postId to reportedPosts: \(postId)")
-                                    self?.showCompletionAlert()
-                                case .failure(let error):
-                                    print("Failed to add to reportedPosts: \(error)")
+                        // Report 저장 후 신고 카운트 증가
+                        PostService.shared.incrementReportCount(postId: postId) { incrementResult in
+                            switch incrementResult {
+                            case .success:
+                                // UserInfo 업데이트
+                                UserInfoService.shared.addReportedPost(postId: postId) { result in
+                                    DispatchQueue.main.async {
+                                        switch result {
+                                        case .success:
+                                            self?.showCompletionAlert()
+                                        case .failure(let error):
+                                            self?.showAlert(title: "오류",
+                                                          message: "신고는 완료되었으나, 신고 목록 업데이트에 실패했습니다.")
+                                        }
+                                    }
+                                }
+                            case .failure(let error):
+                                DispatchQueue.main.async {
                                     self?.showAlert(title: "오류",
-                                                  message: "신고는 완료되었으나, 신고 목록 업데이트에 실패했습니다.")
+                                                  message: "신고 카운트 업데이트에 실패했습니다.")
                                 }
                             }
                         }
                         
                     case .failure(let error):
                         DispatchQueue.main.async {
-                            print("Failed to upload report: \(error)")
                             self?.showAlert(title: "오류",
                                           message: "신고 처리 중 오류가 발생했습니다: \(error.localizedDescription)")
                         }
@@ -470,7 +473,6 @@ class ReportVC: UIViewController, UITextViewDelegate {
                 
             case .failure(let error):
                 DispatchQueue.main.async {
-                    print("Failed to check report status: \(error)")
                     self.showAlert(title: "오류",
                                  message: "신고 이력 확인 중 오류가 발생했습니다: \(error.localizedDescription)")
                 }

--- a/Ting/Post/PostView/ReportVC.swift
+++ b/Ting/Post/PostView/ReportVC.swift
@@ -493,16 +493,20 @@ class ReportVC: UIViewController, UITextViewDelegate {
     }
     
     private func showCompletionAlert() {
+        let message = targetPost?.reportCount ?? 0 >= 4 ?
+            "신고가 접수되었습니다.\n누적 신고로 인해 해당 게시글이 삭제되었습니다." :
+            "신고가 정상적으로 접수되었습니다."
+        
         let alert = UIAlertController(
             title: "신고 완료",
-            message: "신고가 정상적으로 접수되었습니다.",
+            message: message,
             preferredStyle: .alert
         )
         
         let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
             guard let self = self else { return }
-                self.delegate?.didUpdatePostList()
-                self.navigationController?.popToRootViewController(animated: true)
+            self.delegate?.didUpdatePostList()
+            self.navigationController?.popToRootViewController(animated: true)
         }
         
         alert.addAction(confirmAction)


### PR DESCRIPTION
## 변경사항
- 신고하기 버튼 터치 시 해당 게시글의 신고하기 횟수 자동 카운트 기능 구현
- 신고 누적 5회가 된 게시글의 경우에 자동으로 삭제되게 기능 구현

## 주요내용
- PostSevice 파일 수정
   - 게시글 신고 카운트 메서드 구현
   
- Post 파일 수정
   - 신고횟수 카운트 값 세팅
   
- JoinTeamUploadVC
   - 신고횟수 카운트 값 세팅
   
- RecruitMemberUploadVC
   - 신고횟수 카운트 값 세팅
   
- ReportVC
   - 신고 하기 버튼 터치시 신고당하는 게시글의 신고카운트 증가 기능 구현
   - 누적 신고 5회시 자동으로 해당게시글 삭제기능 구현
   - 마무리 일격? 을 날린 사용자에게 마지막 누적 신고로 인한 삭제되었다고 얼럿 추가내용 삽입


Resolves: #212 