### PR TITLE
Feat: 게시글 신고 접수 시, 슬랙으로 메시지를 전송

### DIFF
--- a/Ting/API/SlackService.swift
+++ b/Ting/API/SlackService.swift
@@ -14,7 +14,7 @@ class SlackService {
     // 생성자: Webhook URL을 설정
     init() {
         // MARK: - Slack에서 받은 Webhook URL | 절대 틀리면 안됨.
-        let urlString = "https://hooks.slack.com/services/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"
+        let urlString = "https://hooks.slack.com/services/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"
         
         // URL 문자열을 URL 객체로 변환, 실패할 경우 fatalError로 앱이 종료되도록 처리
         guard let url = URL(string: urlString) else {

--- a/Ting/API/SlackService.swift
+++ b/Ting/API/SlackService.swift
@@ -13,8 +13,8 @@ class SlackService {
     
     // 생성자: Webhook URL을 설정
     init() {
-        // Slack에서 받은 Webhook URL
-        let urlString = "https://hooks.slack.com/services/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"
+        // MARK: - Slack에서 받은 Webhook URL | 절대 틀리면 안됨.
+        let urlString = "https://hooks.slack.com/services/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"
         
         // URL 문자열을 URL 객체로 변환, 실패할 경우 fatalError로 앱이 종료되도록 처리
         guard let url = URL(string: urlString) else {

--- a/Ting/API/SlackService.swift
+++ b/Ting/API/SlackService.swift
@@ -1,0 +1,76 @@
+//
+//  ReportNotification.swift
+//  Ting
+//
+//  Created by 이재건 on 2/14/25.
+//
+
+import Foundation
+
+class SlackService {
+    // Webhook URL을 private 속성으로 관리하여 외부에서 직접 변경할 수 없도록 보호
+    private let webhookURL: URL
+    
+    // 생성자: Webhook URL을 설정
+    init() {
+        // Slack에서 받은 Webhook URL
+        let urlString = "https://hooks.slack.com/services/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"
+        
+        // URL 문자열을 URL 객체로 변환, 실패할 경우 fatalError로 앱이 종료되도록 처리
+        guard let url = URL(string: urlString) else {
+            fatalError("잘못된 Webhook URL입니다.")
+        }
+        
+        // webhookURL에 변환된 URL 저장
+        self.webhookURL = url
+    }
+
+    // Slack으로 메시지를 전송하는 메서드
+    func sendSlackMessage(message: String) {
+        // Slack 메시지를 보내기 위한 HTTP 요청을 생성하는 함수
+        print("sendSlackMessage 함수 호출됨")
+        
+        // URLRequest 객체를 사용하여 POST 요청을 생성
+        var request = URLRequest(url: webhookURL)
+        request.httpMethod = "POST" // HTTP 메서드는 POST
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type") // 요청 헤더에 Content-Type을 JSON으로 설정
+
+        // 전송할 메시지를 JSON 형식으로 변환하기 위한 딕셔너리 생성
+        let body = ["text": message]
+
+        do {
+            // 딕셔너리를 JSON 데이터로 변환
+            let jsonData = try JSONSerialization.data(withJSONObject: body, options: [])
+            request.httpBody = jsonData // 요청의 본문에 JSON 데이터를 할당
+        } catch {
+            // JSON 데이터 변환 실패 시 에러 처리
+            print("JSON 데이터 변환 실패: \(error.localizedDescription)")
+            return
+        }
+
+        // URLSession을 사용하여 네트워크 요청을 비동기로 전송
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                // 요청 실패 시 에러 메시지 출력
+                print("Slack 전송 실패: \(error.localizedDescription)")
+                return
+            }
+
+            // HTTP 응답 코드 출력
+            if let httpResponse = response as? HTTPURLResponse {
+                print("HTTP 상태 코드: \(httpResponse.statusCode)")
+            }
+
+            // 응답 데이터가 있다면 출력
+            if let data = data, let responseString = String(data: data, encoding: .utf8) {
+                print("응답 데이터: \(responseString)")
+            }
+
+            // 메시지 전송 성공 메시지 출력
+            print("Slack 메시지 전송 성공!")
+        }
+
+        // 요청을 비동기로 시작
+        task.resume()
+    }
+}

--- a/Ting/Post/PostView/ReportVC.swift
+++ b/Ting/Post/PostView/ReportVC.swift
@@ -450,6 +450,7 @@ class ReportVC: UIViewController, UITextViewDelegate {
                                         switch result {
                                         case .success:
                                             self?.showCompletionAlert()
+                                            self?.slackService.sendSlackMessage(message: "🚨 새로운 게시글 신고가 접수되었습니다!🚨 (\(Date()))")
                                         case .failure(let error):
                                             self?.showAlert(title: "오류",
                                                           message: "신고는 완료되었으나, 신고 목록 업데이트에 실패했습니다.")
@@ -497,6 +498,7 @@ class ReportVC: UIViewController, UITextViewDelegate {
         let message = targetPost?.reportCount ?? 0 >= 4 ?
             "신고가 접수되었습니다.\n누적 신고로 인해 해당 게시글이 삭제되었습니다." :
             "신고가 정상적으로 접수되었습니다."
+        //self.slackService.sendSlackMessage(message: "🚨 5회이상 신고가 접수되어 삭제된 게시물이 있습니다.🚨 (\(Date()))")
         
         let alert = UIAlertController(
             title: "신고 완료",

--- a/Ting/Post/PostView/ReportVC.swift
+++ b/Ting/Post/PostView/ReportVC.swift
@@ -45,6 +45,7 @@ class ReportVC: UIViewController, UITextViewDelegate {
     private let etcLabel = UILabel()
     private let reportDescriptionTextView = UITextView()
     private let reportButton = UIButton()
+    private let slackService = SlackService()
     
     // MARK: - Initialization
     init(post: Post, reporterNickname: String) {
@@ -436,6 +437,8 @@ class ReportVC: UIViewController, UITextViewDelegate {
             ReportManager.shared.uploadReport(report) { [weak self] result in
                 switch result {
                 case .success:
+                    // Slack으로 신고 접수 메시지 전송
+                    self?.slackService.sendSlackMessage(message: "🚨 새로운 게시글 신고가 접수되었습니다! 🚨")
                     self?.showCompletionAlert()
                 case .failure(let error):
                     print("\(error)")

--- a/Ting/Post/PostView/ReportVC.swift
+++ b/Ting/Post/PostView/ReportVC.swift
@@ -449,8 +449,9 @@ class ReportVC: UIViewController, UITextViewDelegate {
                                     DispatchQueue.main.async {
                                         switch result {
                                         case .success:
-                                            self?.showCompletionAlert()
+                                            // 슬랙으로 메시지 전송
                                             self?.slackService.sendSlackMessage(message: "🚨 새로운 게시글 신고가 접수되었습니다!🚨 (\(Date()))")
+                                            self?.showCompletionAlert()
                                         case .failure(let error):
                                             self?.showAlert(title: "오류",
                                                           message: "신고는 완료되었으나, 신고 목록 업데이트에 실패했습니다.")
@@ -495,10 +496,17 @@ class ReportVC: UIViewController, UITextViewDelegate {
     }
     
     private func showCompletionAlert() {
-        let message = targetPost?.reportCount ?? 0 >= 4 ?
-            "신고가 접수되었습니다.\n누적 신고로 인해 해당 게시글이 삭제되었습니다." :
-            "신고가 정상적으로 접수되었습니다."
-        //self.slackService.sendSlackMessage(message: "🚨 5회이상 신고가 접수되어 삭제된 게시물이 있습니다.🚨 (\(Date()))")
+        
+        // 5회차 신고일때, 게시글 삭제 Alert, 아닐 경우, 일반 Alert 출력
+        let reportCount = targetPost?.reportCount ?? 0
+        let message: String
+        if reportCount >= 4 {
+            message = "신고가 접수되었습니다.\n누적 신고로 인해 해당 게시글이 삭제되었습니다."
+            // 슬랙으로 메시지 전송
+            self.slackService.sendSlackMessage(message: "🚨 5회이상 신고가 접수되어 삭제된 게시물이 있습니다.🚨 (\(Date()))")
+        } else {
+            message = "신고가 정상적으로 접수되었습니다."
+        }
         
         let alert = UIAlertController(
             title: "신고 완료",


### PR DESCRIPTION
## 주요내용
- 게시글 신고 발생 시, 개발진 슬랙으로 메시지를 전송하도록 구현하였습니다.
- 게시글 전송 봇을 만들었고, 다른 서버를 거치지 않고 앱에서 바로 봇으로 메시지를 보내도록 구현하였습니다.


## 스크린샷

<img width="590" alt="스크린샷 2025-02-14 오후 10 26 44" src="https://github.com/user-attachments/assets/b5e127de-9ff9-423f-8f12-14a0bd9862ba" />


## 추가계획, 고민
- 해당 기능으로 다른 주요 상황에서도 개발진 슬랙으로 메시지를 보낼 수 있도록 고민

Resolves: #214