### PR TITLE
Fix: 다크모드 지원x, 기술태크 겹침문제해결

### DIFF
--- a/Ting/Info.plist
+++ b/Ting/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>SLACK_WEBHOOK_URL</key>
 	<string>SLACK_WEBHOOK_URL=https://hooks.slack.com/services/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</string>
 	<key>UIAppFonts</key>

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -286,6 +286,7 @@ class PostDetailVC: UIViewController {
         // 기존 태그들 모두 제거
         statusTagsView.removeAllTags()
         techStacksView.removeAllTags()
+        positionTagsView.removeAllTags()
         
         // 게시글 작성자의 role 정보 가져오기
         let db = Firestore.firestore()


### PR DESCRIPTION
## 변경사항
- 태그 수정시 겹치는 문제 해결
- 다크모드 미적용으로 변경

## 주요내용
- 
-

## 스크린샷

<img width="400" alt="" src="https://github.com/user-attachments/assets/c2e8b905-26f8-410d-b208-452c60cbb865)" />

## 추가계획, 고민
-
- 
- 

Resolves: #이슈번호