### PR TITLE
Fix: 관심사 필드 글자수 리밋 변경, 키보드 내려가는 로직 수정

### DIFF
--- a/Ting.xcodeproj/project.pbxproj
+++ b/Ting.xcodeproj/project.pbxproj
@@ -198,7 +198,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JaegunLee.Ting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -240,7 +240,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JaegunLee.Ting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
+++ b/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
@@ -75,6 +75,7 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
         
         configureUI()
         setupKeyboardNotification()
+        keyboardDown()
         
         // 키보드 설정 위해 delegate 적용
         [nickNameField, roleField, techStackField, toolField, workStyleField, interestField].forEach {
@@ -242,12 +243,12 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
     
     // MARK: 키보드 설정
     //다른 공간 터치시 키보드 사라짐
-    private func setupKeyboardDismissGesture() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+    private func keyboardDown() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(keyboardDownAction))
         tapGesture.cancelsTouchesInView = false // 다른 터치 이벤트도 전달되도록 설정
         view.addGestureRecognizer(tapGesture)
     }
-    @objc private func dismissKeyboard() {
+    @objc private func keyboardDownAction() {
         view.endEditing(true)
     }
     

--- a/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
+++ b/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
@@ -275,6 +275,10 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
             guard let text = textField.text else { return true }
             let newLength = text.count + string.count - range.length
             return newLength <= 40
+        } else if textField == interestField.textField {
+            guard let text = textField.text else { return true }
+            let newLength = text.count + string.count - range.length
+            return newLength <= 40
         } else {
             guard let text = textField.text else { return true }
             let newLength = text.count + string.count - range.length

--- a/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
+++ b/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
@@ -242,9 +242,13 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
     
     // MARK: 키보드 설정
     //다른 공간 터치시 키보드 사라짐
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    private func setupKeyboardDismissGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false // 다른 터치 이벤트도 전달되도록 설정
+        view.addGestureRecognizer(tapGesture)
+    }
+    @objc private func dismissKeyboard() {
         view.endEditing(true)
-        super.touchesBegan(touches, with: event)
     }
     
     // MARK: - 다음 TextField로 포커스 이동, 마지막은 키보드 내리기

--- a/Ting/MyPage/EditInfo/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfo/EditInfoVC.swift
@@ -77,17 +77,11 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
         configureUI()
         fetchUserData()
         setupKeyboardNotification()
-        setupKeyboardDismissGesture()
+        keyboardDown()
         
         // 키보드 설정 위해 delegate 적용
         [nickNameField, roleField, techStackField, toolField, workStyleField, interestField].forEach {
             $0.textField.delegate = self
-        }
-        
-        // 툴바 설정 (키보드에 툴바 표시)
-        let toolbar = self.toolbar() // toolbar() 메서드 호출하여 툴바 설정
-        [nickNameField, roleField, techStackField, toolField, workStyleField, interestField].forEach {
-            $0.textField.inputAccessoryView = toolbar
         }
     }
     
@@ -293,28 +287,12 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
     
     //MARK: 키보드 설정
     // 다른 공간 터치시 키보드 사라짐
-    private func setupKeyboardDismissGesture() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+    private func keyboardDown() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(keyboardDownAction))
         tapGesture.cancelsTouchesInView = false // 다른 터치 이벤트도 전달되도록 설정
         view.addGestureRecognizer(tapGesture)
     }
-    @objc private func dismissKeyboard() {
-        view.endEditing(true)
-    }
-    
-    // 키보드 툴바 (개별항목 수정 후 키보드 내리기용)
-    private func toolbar() -> UIToolbar {
-        let toolbar = UIToolbar()
-        toolbar.sizeToFit()
-        
-        //let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let doneButton = UIBarButtonItem(title: "Done", style: .done, target: self, action: #selector(doneButtonTapped))
-        
-        toolbar.setItems([doneButton], animated: false)
-        //toolbar.setItems([flexibleSpace, doneButton], animated: false)
-        return toolbar
-    }
-    @objc func doneButtonTapped() { // Done버튼 액션
+    @objc private func keyboardDownAction() {
         view.endEditing(true)
     }
     

--- a/Ting/MyPage/EditInfo/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfo/EditInfoVC.swift
@@ -77,10 +77,17 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
         configureUI()
         fetchUserData()
         setupKeyboardNotification()
+        setupKeyboardDismissGesture()
         
         // 키보드 설정 위해 delegate 적용
         [nickNameField, roleField, techStackField, toolField, workStyleField, interestField].forEach {
             $0.textField.delegate = self
+        }
+        
+        // 툴바 설정 (키보드에 툴바 표시)
+        let toolbar = self.toolbar() // toolbar() 메서드 호출하여 툴바 설정
+        [nickNameField, roleField, techStackField, toolField, workStyleField, interestField].forEach {
+            $0.textField.inputAccessoryView = toolbar
         }
     }
     
@@ -285,10 +292,30 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
     }
     
     //MARK: 키보드 설정
-    //다른 공간 터치시 키보드 사라짐
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    // 다른 공간 터치시 키보드 사라짐
+    private func setupKeyboardDismissGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false // 다른 터치 이벤트도 전달되도록 설정
+        view.addGestureRecognizer(tapGesture)
+    }
+    @objc private func dismissKeyboard() {
         view.endEditing(true)
-        super.touchesBegan(touches, with: event)
+    }
+    
+    // 키보드 툴바 (개별항목 수정 후 키보드 내리기용)
+    private func toolbar() -> UIToolbar {
+        let toolbar = UIToolbar()
+        toolbar.sizeToFit()
+        
+        //let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let doneButton = UIBarButtonItem(title: "Done", style: .done, target: self, action: #selector(doneButtonTapped))
+        
+        toolbar.setItems([doneButton], animated: false)
+        //toolbar.setItems([flexibleSpace, doneButton], animated: false)
+        return toolbar
+    }
+    @objc func doneButtonTapped() { // Done버튼 액션
+        view.endEditing(true)
     }
     
     // MARK: - 다음 TextField로 포커스 이동, 마지막은 키보드 내리기

--- a/Ting/MyPage/EditInfo/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfo/EditInfoVC.swift
@@ -213,12 +213,12 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
         } else {
             // 공백 검사
             if isThereSpaces(text: nickname) == true {
-                self.basicAlert(title: "오류", message: "공백은 입력할 수 없습니다.")
+                self.basicAlert(title: "오류", message: "공백 및 특수문자는 입력할 수 없습니다.")
                 return
             }
             // 특수문자 검사
             if isThereSpecialChar(text: nickname) == true {
-                self.basicAlert(title: "오류", message: "특수문자는 입력할 수 없습니다.")
+                self.basicAlert(title: "오류", message: "사용할 수 없는 닉네임입니다.")
                 return
             }
             // 닉네임이 변경된 경우 중복 검사 후 저장
@@ -316,6 +316,10 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
             let newLength = text.count + string.count - range.length
             return newLength <= 40
         } else if textField == toolField.textField {
+            guard let text = textField.text else { return true }
+            let newLength = text.count + string.count - range.length
+            return newLength <= 40
+        } else if textField == interestField.textField {
             guard let text = textField.text else { return true }
             let newLength = text.count + string.count - range.length
             return newLength <= 40


### PR DESCRIPTION
## 변경사항
- 관심사 필드 글자수 제한 20자 -> 40자
- 키보드 내려가는 로직 수정

## 주요내용
- 기존에는 카드뷰를 제외한 바깥 영역을 터치해야만 키보드가 내려가게 구현하였습니다.
하지만 카드뷰가 뷰의 대다수를 차지하고 있기에, 뷰 전체 아무곳이나 클릭해도 키보드가 내려가게 로직을 수정하였습니다.
`UITapGestureRecognizer`를 사용하였습니다.


Resolves: #233 
Resolves: #234 