### PR TITLE
Fix: 게시글 작성, 리스트 1.0.3 피드백 관련 수정

### DIFF
--- a/Ting/API/PostService.swift
+++ b/Ting/API/PostService.swift
@@ -35,8 +35,7 @@ class PostService {
     
     // MARK: - 데이터 Read
     
-    /// 최근글 3개
-    /// 최근글 3개
+    /// 최근글 10개 불러온 후 3개만 표시
     func getLatestPost(type: String, completion: @escaping (Result<[Post], Error>) -> Void) {
         // 1. 차단된 사용자 목록 가져오기
         getBlockedUsers { blockedUsers in

--- a/Ting/CustomView/BaseUploadView.swift
+++ b/Ting/CustomView/BaseUploadView.swift
@@ -60,6 +60,7 @@ class BaseUploadView: UIView {
         super.init(frame: frame)
         setupUI()
         setupTapGesture()
+        detailTextView.delegate = self
     }
     
     required init?(coder: NSCoder) {
@@ -82,19 +83,19 @@ class BaseUploadView: UIView {
     private func setupUI() {
         self.backgroundColor = .background
         
-        addSubviews(scrollView, submitButton)
+        addSubview(scrollView)
         scrollView.addSubview(contentView)
+        contentView.addSubview(submitButton)
         
         submitButton.snp.makeConstraints {
-            $0.bottom.equalTo(safeAreaLayoutGuide).inset(20)
+            $0.bottom.equalToSuperview().inset(20)
             $0.centerX.equalToSuperview()
             $0.horizontalEdges.equalToSuperview().inset(40)
             $0.height.equalTo(50)
         }
         
         scrollView.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(submitButton.snp.top).offset(-16)
+            $0.edges.equalTo(safeAreaLayoutGuide)
         }
         
         contentView.snp.makeConstraints {
@@ -102,4 +103,32 @@ class BaseUploadView: UIView {
             $0.width.equalTo(scrollView.frameLayoutGuide)
         }
     }
+}
+
+extension BaseUploadView: UITextViewDelegate {
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        guard let currentText = textView.text else { return true }
+
+        // 새롭게 입력될 텍스트 적용
+        let newText = (currentText as NSString).replacingCharacters(in: range, with: text)
+
+        // 글자 수 제한 (500자)
+        if newText.count > 500 {
+            return false
+        }
+
+        // 줄바꿈 개수 제한 (30줄)
+        let lines = newText.components(separatedBy: .newlines)
+        if lines.count > 30 {
+            return false
+        }
+
+        // 마지막 줄의 글자수 제한 (30자) 마지막 줄에서 의도적으로 길게 적는 것 방지
+        if let lastLine = lines.last, lastLine.count > 30 {
+            return false
+        }
+
+        return true
+    }
+    
 }

--- a/Ting/Post/PostView/JoinTeamUploadVC.swift
+++ b/Ting/Post/PostView/JoinTeamUploadVC.swift
@@ -62,13 +62,23 @@ final class JoinTeamUploadVC: UIViewController {
               !selectedTeamSize.isEmpty,
               !selectedMeetingStyle.isEmpty,
               !selectedCurrentStatus.isEmpty,
-        let techInput = uploadView.techStackTextField.textField.text,
-        !techInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-        let titleInput = uploadView.titleSection.textField.text,
-        !titleInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-        let detailInput = uploadView.detailTextView.text,
-        !detailInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else{
+              let techInput = uploadView.techStackTextField.textField.text,
+              !techInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let titleInput = uploadView.titleSection.textField.text,
+              !titleInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let detailInput = uploadView.detailTextView.text,
+              !detailInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else{
             basicAlert(title: "입력 필요", message: "빈칸을 채워주세요")
+            return
+        }
+        
+        let techArray = techInput.components(separatedBy: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        
+        // 각 기술 스택 글자 수 검사
+        if techArray.contains(where: { $0.count > 10 }) {
+            basicAlert(title: "글자 수 초과", message: "기술 스택은 10글자 이하로 입력해주세요.")
             return
         }
         
@@ -82,9 +92,8 @@ final class JoinTeamUploadVC: UIViewController {
             switch result {
             case .success(let userInfo):
                 
-                let techArray = techInput.components(separatedBy: ",")
-                    .map { $0.trimmingCharacters(in: .whitespaces) }
-                    .filter { !$0.isEmpty }
+                let trimmedTitle = titleInput.trimmingCharacters(in: .whitespacesAndNewlines)
+                let trimmedDetail = detailInput.trimmingCharacters(in: .whitespacesAndNewlines)
                 let keywords = PostService.shared.generateSearchKeywords(from: titleInput)
                 
                 let post = Post(
@@ -92,8 +101,8 @@ final class JoinTeamUploadVC: UIViewController {
                     userId: userId,
                     nickName: userInfo.nickName,
                     postType: postType.rawValue,
-                    title: titleInput,
-                    detail: detailInput,
+                    title: trimmedTitle,
+                    detail: trimmedDetail,
                     position: selectedPositions,
                     techStack: techArray,
                     ideaStatus: selectedIdeaStatus,
@@ -179,6 +188,10 @@ extension JoinTeamUploadVC: LabelAndTagSectionDelegate {
 }
 
 extension JoinTeamUploadVC: UITextFieldDelegate {
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+    }
     
     // 글자 수 제한 제목 20자 이하, 기술스택 30자 이하
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {

--- a/Ting/Post/PostView/JoinTeamUploadVC.swift
+++ b/Ting/Post/PostView/JoinTeamUploadVC.swift
@@ -23,7 +23,6 @@ final class JoinTeamUploadVC: UIViewController {
     var selectedMeetingStyle = ""
     var selectedCurrentStatus = ""
     
-    weak var delegate: PostListUpdater?
     var isEditMode = false
     var editPostId: String?
     
@@ -126,7 +125,7 @@ final class JoinTeamUploadVC: UIViewController {
                             
                             // 데이터 최신화 업로드
                             NotificationCenter.default.post(
-                                name: .userInfoUpdated,
+                                name: .postUpdated,
                                 object: nil
                             )
                             
@@ -141,7 +140,8 @@ final class JoinTeamUploadVC: UIViewController {
                     PostService.shared.uploadPost(post: post) { [weak self] result in
                         switch result {
                         case .success:
-                            self?.delegate?.didUpdatePostList()
+                            // 리스트 업데이트 알림 보내기
+                            NotificationCenter.default.post(name: .postUpdated, object: nil)
                             self?.navigationController?.popViewController(animated: true)
                         case .failure(let error):
                             print("\(error)")

--- a/Ting/Post/PostView/JoinTeamUploadVC.swift
+++ b/Ting/Post/PostView/JoinTeamUploadVC.swift
@@ -91,6 +91,7 @@ final class JoinTeamUploadVC: UIViewController {
             switch result {
             case .success(let userInfo):
                 
+                // 텍스트 앞뒤 공백 제거
                 let trimmedTitle = titleInput.trimmingCharacters(in: .whitespacesAndNewlines)
                 let trimmedDetail = detailInput.trimmingCharacters(in: .whitespacesAndNewlines)
                 let keywords = PostService.shared.generateSearchKeywords(from: titleInput)

--- a/Ting/Post/PostView/JoinTeamUploadView.swift
+++ b/Ting/Post/PostView/JoinTeamUploadView.swift
@@ -143,8 +143,8 @@ final class JoinTeamUploadView: BaseUploadView {
         detailTextView.snp.makeConstraints {
             $0.top.equalTo(detailLabel.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview().inset(16)
-            $0.height.equalTo(360)
-            $0.bottom.equalToSuperview().offset(-20)
+            $0.height.equalTo(600)
+            $0.bottom.equalTo(submitButton.snp.top).offset(-16)
         }
     }
 }

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -41,7 +41,6 @@ class PostDetailVC: UIViewController {
     private let postType: PostType
     private var post: Post?
     private let currentUserNickname: String
-    weak var delegate: PostListUpdater?
     
     // MARK: - Initialization
     init(postType: PostType, post: Post, currentUserNickname: String) {
@@ -352,13 +351,13 @@ class PostDetailVC: UIViewController {
         authInfoButton.addTarget(self, action: #selector(authInfoButtonTapped), for: .touchUpInside)
         
         reportButton.setTitle("신고하기", for: .normal)
-            reportButton.backgroundColor = .background
-            reportButton.layer.cornerRadius = 10
-            reportButton.layer.borderColor = UIColor.accent.cgColor // 테두리 색상 추가
-            reportButton.layer.borderWidth = 1.5 // 테두리 두께 추가
-            reportButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
-            reportButton.setTitleColor(.accent, for: .normal) // 텍스트 색상을 accent로 변경
-            reportButton.addTarget(self, action: #selector(reportButtonTapped), for: .touchUpInside)
+        reportButton.backgroundColor = .background
+        reportButton.layer.cornerRadius = 10
+        reportButton.layer.borderColor = UIColor.accent.cgColor // 테두리 색상 추가
+        reportButton.layer.borderWidth = 1.5 // 테두리 두께 추가
+        reportButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
+        reportButton.setTitleColor(.accent, for: .normal) // 텍스트 색상을 accent로 변경
+        reportButton.addTarget(self, action: #selector(reportButtonTapped), for: .touchUpInside)
         
         editButton.setTitle("편집하기", for: .normal)
         editButton.backgroundColor = .primaries
@@ -530,14 +529,14 @@ class PostDetailVC: UIViewController {
             make.left.right.equalToSuperview().inset(20)
             make.bottom.equalToSuperview().inset(16)  // whiteCardView의 하단과의 간격
         }
-       
+        
         reportButton.snp.makeConstraints { make in
             make.top.equalTo(whiteCardView.snp.bottom).offset(16)
             make.leading.trailing.equalToSuperview().inset(40)
             make.bottom.equalToSuperview().inset(20)
             make.height.equalTo(50)
         }
-
+        
         editButton.snp.makeConstraints { make in
             make.top.equalTo(whiteCardView.snp.bottom).offset(16)
             make.leading.trailing.equalToSuperview().inset(40)
@@ -547,25 +546,29 @@ class PostDetailVC: UIViewController {
     }
     
     @objc private func authInfoButtonTapped() {
+        
+        guard self.loginCheck() else { return }
+        
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
-//        let profileInfo = UIAlertAction(title: "프로필보기", style: .default) { [weak self] _ in
-//            self?.basicAlert(title: "업데이트 예정", message: "조금만 기다려주세요😊")
-//        }
+        //        let profileInfo = UIAlertAction(title: "프로필보기", style: .default) { [weak self] _ in
+        //            self?.basicAlert(title: "업데이트 예정", message: "조금만 기다려주세요😊")
+        //        }
         
         let blockUser = UIAlertAction(title: "차단하기", style: .destructive) { [weak self] _ in
             
             let confirmAlert = UIAlertController(title: "🚨 작성자 차단", message: "해당 사용자의 모든 게시글이 보이지 않습니다.", preferredStyle: .alert)
-                // 확인 액션
-                let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
+            // 확인 액션
+            let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
                 
                 guard let post = self?.post else { return }
-                    
+                
                 // 차단할 사용자의 uid로 차단목록에 추가
-                    UserInfoService.shared.blockUser(userId: post.userId) { result in
+                UserInfoService.shared.blockUser(userId: post.userId) { result in
                     switch result {
                     case .success:
-                        self?.delegate?.didUpdatePostList()
+                        // 리스트 업데이트 알림 보내기
+                        NotificationCenter.default.post(name: .postUpdated, object: nil)
                         self?.navigationController?.popViewController(animated: true)
                     case .failure(let error):
                         print("\(error)")
@@ -576,7 +579,7 @@ class PostDetailVC: UIViewController {
             
             // 취소 액션
             let cancelAction = UIAlertAction(title: "취소", style: .destructive)
-                    
+            
             confirmAlert.addAction(confirmAction)
             confirmAlert.addAction(cancelAction)
             self?.present(confirmAlert, animated: true)
@@ -584,21 +587,20 @@ class PostDetailVC: UIViewController {
         
         let cancel = UIAlertAction(title: "취소", style: .cancel)
         
-//        alert.addAction(profileInfo)
+        //        alert.addAction(profileInfo)
         alert.addAction(blockUser)
         alert.addAction(cancel)
         self.present(alert, animated: true)
     }
     
     @objc private func reportButtonTapped() {
-    
+        
         /// 회원인지 비회원인지 체크
         guard self.loginCheck() else { return }
         
         guard let post = post else { return }
         
         let reportVC = ReportVC(post: post, reporterNickname: currentUserNickname)
-        reportVC.delegate = self
         navigationController?.pushViewController(reportVC, animated: true)
     }
     
@@ -614,7 +616,6 @@ class PostDetailVC: UIViewController {
                 let uploadVC = RecruitMemberUploadVC()
                 uploadVC.isEditMode = true
                 uploadVC.editPostId = post.id
-                uploadVC.delegate = self
                 
                 // 기존 데이터 설정
                 uploadVC.selectedPositions = post.position
@@ -644,7 +645,6 @@ class PostDetailVC: UIViewController {
                 let uploadVC = JoinTeamUploadVC()
                 uploadVC.isEditMode = true
                 uploadVC.editPostId = post.id
-                uploadVC.delegate = self
                 
                 // 기존 데이터 설정
                 uploadVC.selectedPositions = post.position
@@ -688,7 +688,8 @@ class PostDetailVC: UIViewController {
                     case .success:
                         // 삭제 성공 시 이전 화면으로 돌아가기
                         DispatchQueue.main.async {
-                            self?.delegate?.didUpdatePostList()
+                            // 리스트 업데이트 알림 보내기
+                            NotificationCenter.default.post(name: .postUpdated, object: nil)
                             self?.navigationController?.popViewController(animated: true)
                         }
                     case .failure(let error):
@@ -715,10 +716,3 @@ class PostDetailVC: UIViewController {
         present(alert, animated: true)
     }
 }
-
-extension PostDetailVC: PostListUpdater {
-       func didUpdatePostList() {
-           // PostListVC에 업데이트 요청
-           self.delegate?.didUpdatePostList()
-       }
-   }

--- a/Ting/Post/PostView/PostDetailVC.swift
+++ b/Ting/Post/PostView/PostDetailVC.swift
@@ -546,7 +546,7 @@ class PostDetailVC: UIViewController {
     }
     
     @objc private func authInfoButtonTapped() {
-        
+        // 로그인 검증
         guard self.loginCheck() else { return }
         
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)

--- a/Ting/Post/PostView/PostListVC.swift
+++ b/Ting/Post/PostView/PostListVC.swift
@@ -9,10 +9,6 @@ import UIKit
 import SnapKit
 import FirebaseFirestore
 
-protocol PostListUpdater: AnyObject {
-    func didUpdatePostList()
-}
-
 final class PostListVC: UIViewController {
     
     private let postListView = PostListView()
@@ -52,6 +48,13 @@ final class PostListVC: UIViewController {
             self,
             selector: #selector(handleUserInfoUpdated),
             name: .userInfoUpdated,
+            object: nil
+        )
+        // 게시글 업데이트 알림 수신 등록
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handlePostUpdated),
+            name: .postUpdated,
             object: nil
         )
     }
@@ -99,6 +102,10 @@ final class PostListVC: UIViewController {
         refreshData()
     }
     
+    @objc private func handlePostUpdated() {
+        refreshData() // 리스트 새로 고침
+    }
+    
     // 네비바 글쓰기 버튼 클릭 시 해당 게시판의 글작성뷰로 이동
     @objc private func createPostButtonTapped() {
         // 로그인한 유저인지 아닌지 체크
@@ -108,13 +115,11 @@ final class PostListVC: UIViewController {
         case .recruitMember:
             // 팀원 모집 글작성 뷰컨
             let uploadVC = RecruitMemberUploadVC()
-            uploadVC.delegate = self
             navigationController?.pushViewController(uploadVC, animated: true)
             
         case .joinTeam:
             // 팀 합류 글작성 뷰컨
             let uploadVC = JoinTeamUploadVC()
-            uploadVC.delegate = self
             navigationController?.pushViewController(uploadVC, animated: true)
         case .none:
             return
@@ -249,9 +254,8 @@ extension PostListVC: UICollectionViewDelegate {
                 // DetailVC로 이동하면서 현재 사용자의 닉네임 전달
                 DispatchQueue.main.async {
                     let postDetailVC = PostDetailVC(postType: postType,
-                                                 post: post,
-                                                 currentUserNickname: userInfo.nickName)
-                    postDetailVC.delegate = self
+                                                    post: post,
+                                                    currentUserNickname: userInfo.nickName)
                     self.navigationController?.pushViewController(postDetailVC, animated: true)
                 }
                 
@@ -260,8 +264,8 @@ extension PostListVC: UICollectionViewDelegate {
                 // 에러 발생 시에도 DetailVC는 보여주되, 닉네임은 빈 문자열로 전달
                 DispatchQueue.main.async {
                     let postDetailVC = PostDetailVC(postType: postType,
-                                                 post: post,
-                                                 currentUserNickname: "")
+                                                    post: post,
+                                                    currentUserNickname: "")
                     self.navigationController?.pushViewController(postDetailVC, animated: true)
                 }
             }
@@ -280,12 +284,10 @@ extension PostListVC: UICollectionViewDelegateFlowLayout {
     }
 }
 
-// MARK: - 리스트 새로고침 delegate
-extension PostListVC: PostListUpdater {
-    func didUpdatePostList() {
-        // 데이터 새로고침 로직
-        loadInitialData()
-    }
+/// 노티피케이션 이름 설정
+extension Notification.Name {
+    static let postUpdated = Notification.Name("postUpdated")
 }
+
 /// prefetchItemAt 알아보고 적용해보기
 /// hasMoreData, reload 관련 코드 수정 필요

--- a/Ting/Post/PostView/RecruitMemberUploadVC.swift
+++ b/Ting/Post/PostView/RecruitMemberUploadVC.swift
@@ -23,7 +23,6 @@ final class RecruitMemberUploadVC: UIViewController {
     var selectedMeetingStyle = ""
     var selectedExperience = ""
     
-    weak var delegate: PostListUpdater?
     var isEditMode = false
     var editPostId: String?
     
@@ -130,7 +129,7 @@ final class RecruitMemberUploadVC: UIViewController {
                             
                             // 데이터 최신화 업로드
                             NotificationCenter.default.post(
-                                name: .userInfoUpdated,
+                                name: .postUpdated,
                                 object: nil
                             )
                             
@@ -145,7 +144,8 @@ final class RecruitMemberUploadVC: UIViewController {
                     PostService.shared.uploadPost(post: post) { [weak self] result in
                         switch result {
                         case .success:
-                            self?.delegate?.didUpdatePostList()
+                            // 리스트 업데이트 알림 보내기
+                            NotificationCenter.default.post(name: .postUpdated, object: nil)
                             self?.navigationController?.popViewController(animated: true)
                         case .failure(let error):
                             print("\(error)")

--- a/Ting/Post/PostView/RecruitMemberUploadVC.swift
+++ b/Ting/Post/PostView/RecruitMemberUploadVC.swift
@@ -76,6 +76,16 @@ final class RecruitMemberUploadVC: UIViewController {
             return
         }
         
+        let techArray = techInput.components(separatedBy: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        
+        // 각 기술 스택 글자 수 검사
+        if techArray.contains(where: { $0.count > 10 }) {
+            basicAlert(title: "글자 수 초과", message: "기술 스택은 10글자 이하로 입력해주세요.")
+            return
+        }
+        
         // UserDefaults에서 userId 확인
         guard let userId = UserDefaults.standard.string(forKey: "userId") else { return }
         
@@ -86,9 +96,8 @@ final class RecruitMemberUploadVC: UIViewController {
             switch result {
             case .success(let userInfo):
                 
-                let techArray = techInput.components(separatedBy: ",")
-                    .map { $0.trimmingCharacters(in: .whitespaces) }
-                    .filter { !$0.isEmpty }
+                let trimmedTitle = titleInput.trimmingCharacters(in: .whitespacesAndNewlines)
+                let trimmedDetail = detailInput.trimmingCharacters(in: .whitespacesAndNewlines)
                 let keywords = PostService.shared.generateSearchKeywords(from: titleInput)
                 
                 let post = Post(
@@ -96,8 +105,8 @@ final class RecruitMemberUploadVC: UIViewController {
                     userId: userId,
                     nickName: userInfo.nickName,
                     postType: postType.rawValue,
-                    title: titleInput,
-                    detail: detailInput,
+                    title: trimmedTitle,
+                    detail: trimmedDetail,
                     position: selectedPositions,
                     techStack: techArray,
                     ideaStatus: selectedIdeaStatus,
@@ -183,6 +192,10 @@ extension RecruitMemberUploadVC: LabelAndTagSectionDelegate {
 }
 
 extension RecruitMemberUploadVC: UITextFieldDelegate {
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+    }
     
     // 글자 수 제한 제목 20자 이하, 기술스택 30자 이하
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {

--- a/Ting/Post/PostView/RecruitMemberUploadVC.swift
+++ b/Ting/Post/PostView/RecruitMemberUploadVC.swift
@@ -95,6 +95,7 @@ final class RecruitMemberUploadVC: UIViewController {
             switch result {
             case .success(let userInfo):
                 
+                // 텍스트 앞뒤 공백 제거
                 let trimmedTitle = titleInput.trimmingCharacters(in: .whitespacesAndNewlines)
                 let trimmedDetail = detailInput.trimmingCharacters(in: .whitespacesAndNewlines)
                 let keywords = PostService.shared.generateSearchKeywords(from: titleInput)

--- a/Ting/Post/PostView/RecruitMemberUploadView.swift
+++ b/Ting/Post/PostView/RecruitMemberUploadView.swift
@@ -145,8 +145,8 @@ final class RecruitMemberUploadView: BaseUploadView {
         detailTextView.snp.makeConstraints {
             $0.top.equalTo(detailLabel.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview().inset(16)
-            $0.height.equalTo(400)
-            $0.bottom.equalToSuperview().offset(-20)
+            $0.height.equalTo(600)
+            $0.bottom.equalTo(submitButton.snp.top).offset(-16)
         }
     }
 }

--- a/Ting/Post/PostView/ReportVC.swift
+++ b/Ting/Post/PostView/ReportVC.swift
@@ -14,7 +14,6 @@ class ReportVC: UIViewController, UITextViewDelegate {
     private var selectedReason: String?
     private var targetPost: Post?
     private var reporterNickname: String?
-//    weak var delegate: PostListUpdater?
     
     // MARK: - UI Components
     private let scrollView = UIScrollView()
@@ -516,8 +515,8 @@ class ReportVC: UIViewController, UITextViewDelegate {
         
         let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
             guard let self = self else { return }
-            NotificationCenter.default.post(name: .postUpdated, object: nil) // 알림 보내기
-//            self.delegate?.didUpdatePostList()
+            // 리스트 업데이트 알림 보내기
+            NotificationCenter.default.post(name: .postUpdated, object: nil)
             self.navigationController?.popToRootViewController(animated: true)
         }
         

--- a/Ting/Post/PostView/ReportVC.swift
+++ b/Ting/Post/PostView/ReportVC.swift
@@ -14,7 +14,7 @@ class ReportVC: UIViewController, UITextViewDelegate {
     private var selectedReason: String?
     private var targetPost: Post?
     private var reporterNickname: String?
-    weak var delegate: PostListUpdater?
+//    weak var delegate: PostListUpdater?
     
     // MARK: - UI Components
     private let scrollView = UIScrollView()
@@ -516,7 +516,8 @@ class ReportVC: UIViewController, UITextViewDelegate {
         
         let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
             guard let self = self else { return }
-            self.delegate?.didUpdatePostList()
+            NotificationCenter.default.post(name: .postUpdated, object: nil) // 알림 보내기
+//            self.delegate?.didUpdatePostList()
             self.navigationController?.popToRootViewController(animated: true)
         }
         


### PR DESCRIPTION
## 변경사항
- 게시글 작성페이지 UX 관련 수정
- 게시글 리스트 새로고침 delegate -> Notification 으로 변경
- 최근게시글 10개 불러온뒤 거르는 방식으로 변경

## 주요내용
- 텍스트필드 done 버튼 클릭 시 키보드 내리기
- 기술스택 글자수 제한
- 텍스트뷰 줄바꿈, 글자수 제한
- 작성페이지 버튼 오토레이아웃 수정 ( 화면 늘어날 시 보이도록 )
- 차단기능 로그인 검증 추가
- 게시글 리스트 새로고침 delegate -> Notification 으로 변경
- 최근 게시글 관련 신고, 차단 시 메인에서 3개가 안보여지는 현상으로
10개 불러온 후 걸러내는 방식으로 변경

## 추가계획, 고민
- UX 관련 수정하였으나 테스트 필요
- 새로고침 관련 delegate로 하려다 보니 복잡하여 Notification으로 하니 간단해짐
- 최근게시글 10개 불러오는 방식이 올바른지 고민 필요 ( 서버 사용량 관련 )
- 노티피케이션 추가하면서 ListVC에 두개의 알림 등록이 되어있는데
 해당 부분은 추후 더 학습해보면 좋을 것 같습니다.

Resolves: #이슈번호 추가예정