### PR TITLE
Feat: 약관 동의, 약관 URL 이동 수정

### DIFF
--- a/Ting/SignUp/SignUpView/TermsCell.swift
+++ b/Ting/SignUp/SignUpView/TermsCell.swift
@@ -15,6 +15,9 @@ class TermsCell: UITableViewCell {
     // 체크 상태 변경 시 호출될 클로저
     var onCheckToggle: (() -> Void)?
     
+    // URL 저장을 위한 프로퍼티 추가
+    private var url: URL?
+
     // 체크 아이콘 (사용자가 누르면 토글됨)
     private let checkIcon = UIImageView().then {
         $0.image = UIImage(systemName: "checkmark.circle.fill")
@@ -76,9 +79,10 @@ class TermsCell: UITableViewCell {
     func configure(text: String, isChecked: Bool, url: URL?) {
         termLabel.text = text
         updateCheckState(isChecked) // UI 동기화
-        
+        self.url = url  // URL 저장
+
         // 특정 텍스트에 대해 화살표 숨기기
-        arrowIcon.isHidden = (text == "(필수) 만 14세 이상입니다")
+        arrowIcon.isHidden = (url == nil)
     }
     
     // MARK: - 체크 상태 업데이트
@@ -90,13 +94,22 @@ class TermsCell: UITableViewCell {
     private func setupTapGestures() {
         let checkTapGesture = UITapGestureRecognizer(target: self, action: #selector(toggleCheck))
         let textTapGesture = UITapGestureRecognizer(target: self, action: #selector(toggleCheck))  // 텍스트도 같은 동작
-        
+        let arrowTapGesture = UITapGestureRecognizer(target: self, action: #selector(openLink))  // 화살표는 링크 열기
+
         checkIcon.addGestureRecognizer(checkTapGesture)
         termLabel.addGestureRecognizer(textTapGesture)
+        arrowIcon.addGestureRecognizer(arrowTapGesture) // 추가된 부분
     }
     
     // MARK: - 체크 상태 변경 (토글)
     @objc private func toggleCheck() {
         onCheckToggle?()  // 부모 뷰 컨트롤러에서 상태 변경 수행
+    }
+
+    // MARK: - 화살표 아이콘 클릭 시 동작 (URL 열기)
+    @objc private func openLink() {
+        if let url = self.url { // URL이 있는 경우에만 열기
+            UIApplication.shared.open(url)
+        }
     }
 }

--- a/Ting/SignUp/SignUpView/TermsCell.swift
+++ b/Ting/SignUp/SignUpView/TermsCell.swift
@@ -12,11 +12,8 @@ import Then
 /// 약관 동의 항목을 위한 테이블뷰 셀
 class TermsCell: UITableViewCell {
     
-    // 화살표 클릭 시 호출될 클로저
-    var onArrowTap: (() -> Void)?
-    
     // 체크 상태 변경 시 호출될 클로저
-    var onCheckToggle: ((Bool) -> Void)?
+    var onCheckToggle: (() -> Void)?
     
     // 체크 아이콘 (사용자가 누르면 토글됨)
     private let checkIcon = UIImageView().then {
@@ -29,6 +26,7 @@ class TermsCell: UITableViewCell {
     private let termLabel = UILabel().then {
         $0.font = UIFont.systemFont(ofSize: 16)
         $0.textColor = .black
+        $0.isUserInteractionEnabled = true  // 텍스트도 터치 가능하도록 설정
     }
     
     // 화살표 아이콘 (약관 보기 버튼)
@@ -38,19 +36,11 @@ class TermsCell: UITableViewCell {
         $0.isUserInteractionEnabled = true  // 사용자 터치 가능하도록 설정
     }
     
-    // 현재 체크 상태 저장
-    private var isChecked = false {
-        didSet {
-            checkIcon.tintColor = isChecked ? .accent : .gray
-            onCheckToggle?(isChecked)  // 체크 상태 변경 시 클로저 호출
-        }
-    }
-    
     // MARK: - 초기화
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
-        setupTapGestures()  // 체크 및 화살표 아이콘에 클릭 이벤트 추가
+        setupTapGestures()  // 체크 및 텍스트 클릭 이벤트 추가
     }
     
     required init?(coder: NSCoder) {
@@ -83,37 +73,30 @@ class TermsCell: UITableViewCell {
     }
     
     // MARK: - 셀 데이터 설정 (초기 상태 설정)
-    func configure(text: String, isRequired: Bool, isChecked: Bool, url: URL?) {
+    func configure(text: String, isChecked: Bool, url: URL?) {
         termLabel.text = text
-        self.isChecked = isChecked  // 초기 상태 설정
+        updateCheckState(isChecked) // UI 동기화
         
         // 특정 텍스트에 대해 화살표 숨기기
         arrowIcon.isHidden = (text == "(필수) 만 14세 이상입니다")
-        
-        // 화살표 클릭 시 호출될 클로저 설정
-        onArrowTap = {
-            if let url = url {
-                UIApplication.shared.open(url)
-            }
-        }
+    }
+    
+    // MARK: - 체크 상태 업데이트
+    private func updateCheckState(_ isChecked: Bool) {
+        checkIcon.tintColor = isChecked ? .accent : .gray
     }
     
     // MARK: - 체크 및 화살표 클릭 이벤트 설정
     private func setupTapGestures() {
         let checkTapGesture = UITapGestureRecognizer(target: self, action: #selector(toggleCheck))
-        checkIcon.addGestureRecognizer(checkTapGesture)
+        let textTapGesture = UITapGestureRecognizer(target: self, action: #selector(toggleCheck))  // 텍스트도 같은 동작
         
-        let arrowTapGesture = UITapGestureRecognizer(target: self, action: #selector(arrowTapped))
-        arrowIcon.addGestureRecognizer(arrowTapGesture)
+        checkIcon.addGestureRecognizer(checkTapGesture)
+        termLabel.addGestureRecognizer(textTapGesture)
     }
     
     // MARK: - 체크 상태 변경 (토글)
     @objc private func toggleCheck() {
-        isChecked.toggle()
-    }
-    
-    // MARK: - 화살표 아이콘 클릭 시 동작
-    @objc private func arrowTapped() {
-        onArrowTap?()  // 설정된 URL로 이동
+        onCheckToggle?()  // 부모 뷰 컨트롤러에서 상태 변경 수행
     }
 }


### PR DESCRIPTION
## 변경사항
- updateAllAgreeButtonState()를 호출하여 "모두 동의" 상태를 동기화.
- onCheckToggle을 isCheckd.toggle()과 연동하여 즉시 반영.

## 주요내용
- "모두 동의" 버튼이 정확히 동작하지 않아 각 상태를 동기화
- 개별 체크가 가끔 풀리지 않거나 동의 체크가 되지 않아 토글을 연동하고, 체크 아이콘과 텍스트 클릭을 하나로 통합해 둘 중 어디를 눌러도 정확하게 체크되도록 수정.
- 아이콘, 텍스트 통합 후 약관 URL로 이동되지 않아 이동 버튼에 별도의 터치 이벤트 설정.

## 스크린샷
.

## 추가계획, 고민
- 회원가입 약관 동의 이탈 이슈
- 기타 버그 확인

Resolves: #240 
Resolves: #241 