### PR TITLE
Feat: 닉네임 이외 텍스트필드 공백, 특수문자 검증 로직 구현

### DIFF
--- a/Ting.xcodeproj/project.pbxproj
+++ b/Ting.xcodeproj/project.pbxproj
@@ -180,7 +180,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 76CW3C5UU7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -198,7 +198,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JaegunLee.Ting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -222,7 +222,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 76CW3C5UU7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -240,7 +240,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.JaegunLee.Ting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Ting/Extension/SpacesAndSpecialChar.swift
+++ b/Ting/Extension/SpacesAndSpecialChar.swift
@@ -16,3 +16,8 @@ func isThereSpaces(text: String) -> Bool { // 어느곳이던 공백이 포함�
 func isThereSpecialChar(text: String) -> Bool { // 어느곳이던 특수문자가 포함되어있으면 true return
     return text.range(of: "[^a-zA-Z0-9가-힣]", options: .regularExpression) != nil
 }
+
+// MARK: - 첫 글자가 공백인지 체크
+func isFirstCharSpace(text: String) -> Bool {
+    return text.first == " "
+}

--- a/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
+++ b/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
@@ -175,19 +175,52 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
     // MARK: - Save Button Action & Firebase에 업로드
     @objc
     private func saveBtnTapped() {
-        // MARK: 닉네임 중복 검사
-        let nickname = nickNameField.textField.text ?? ""
+        // MARK: - 닉네임 제외 다른 필드 공백, 특수문자 검사
+        // 텍스트 필드 배열 생성
+        let otherFields: [UITextField] = [ // , 안쓰는 필드
+            roleField.textField,
+            workStyleField.textField,
+            interestField.textField
+        ]
+        let techAndStackField: [UITextField] = [ // , 쓰는 필드
+            techStackField.textField,
+            toolField.textField
+        ]
+        // 검사 실행
+        for checkSpaceAndSpecial in otherFields { // , 안쓰는 필드 | 공백, 특수문자 검사
+            let text = checkSpaceAndSpecial.text ?? ""
+            // 공백검사
+            if isThereSpaces(text: text) == true {
+                self.basicAlert(title: "오류", message: "공백 및 특수문자는 입력할 수 없습니다.")
+                return
+            }
+            // 특수문자 검사
+            if isThereSpecialChar(text: text) == true {
+                self.basicAlert(title: "오류", message: "사용할 수 없는 닉네임입니다.")
+                return
+            }
+        }
+        for checkSpace in techAndStackField { // , 쓰는 필드 | 공백 검사
+            let text = checkSpace.text ?? ""
+            // 공백검사
+            if isThereSpaces(text: text) == true {
+                self.basicAlert(title: "오류", message: "공백 및 특수문자는 입력할 수 없습니다.")
+                return
+            }
+        }
         
-        //아래 세가지 검사 순차적으로 진행
+        // MARK: 닉네임 중복 검사
+        // 닉네임 검사 시 아래 세가지 검사 순차적으로 진행
+        let nickname = nickNameField.textField.text ?? "" // 현재 텍스트필드에 있는 닉네임
         
         // 공백 검사
         if isThereSpaces(text: nickname) == true {
-            self.basicAlert(title: "오류", message: "공백은 입력할 수 없습니다.")
+            self.basicAlert(title: "오류", message: "공백 및 특수문자는 입력할 수 없습니다.")
             return
         }
         // 특수문자 검사
         if isThereSpecialChar(text: nickname) == true {
-            self.basicAlert(title: "오류", message: "특수문자는 입력할 수 없습니다.")
+            self.basicAlert(title: "오류", message: "사용할 수 없는 닉네임입니다.")
             return
         }
         // 중복검사 실행
@@ -198,46 +231,48 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
                 DispatchQueue.main.async {
                     self.basicAlert(title: "오류", message: "중복된 닉네임입니다.\n다른 닉네임을 입력해 주세요.")
                 }
-                return
             }
-            
-            // MARK: - Firebase Create
-            // userInfo 객체 생성
-            let userInfo = UserInfo(
-                userId: userId,
-                nickName: nickNameField.textField.text ?? "",
-                role: roleField.textField.text ?? "",
-                techStack: techStackField.textField.text ?? "",
-                tool: toolField.textField.text ?? "",
-                workStyle: workStyleField.textField.text ?? "",
-                interest: interestField.textField.text ?? ""
-            )
-            
-            // textField가 다 채워졌는지 확인하기 위해 배열에 저장
-            let isAddInfoEmpty = [
-                userInfo.nickName,
-                userInfo.role,
-                userInfo.techStack,
-                userInfo.tool,
-                userInfo.workStyle,
-                userInfo.interest
-            ]
-            
-            // 텍스트 필드가 전부 채워졌는지 확인하고 서버에 업로드
-            if isAddInfoEmpty.allSatisfy({ !$0.isEmpty }) {
-                UserInfoService.shared.createUserInfo(info: userInfo) { result in
-                    switch result {
-                    case .success:
-                        let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
-                        sceneDelegate?.window?.rootViewController = TabBar() // 메인화면으로 이동
-                        print("회원정보 업로드 성공. | UserDefaults 저장 성공 | MainView로 이동함")
-                    case .failure(let error):
-                        print("업로드 실패: \(error)")
-                    }
+            // 저장진행
+            self.saveUserInfo()
+        }
+    }
+    // MARK: - 입력된 회원정보 서버에 업로드 Firebase Create
+    private func saveUserInfo() {
+        // userInfo 객체 생성
+        let userInfo = UserInfo(
+            userId: userId,
+            nickName: nickNameField.textField.text ?? "",
+            role: roleField.textField.text ?? "",
+            techStack: techStackField.textField.text ?? "",
+            tool: toolField.textField.text ?? "",
+            workStyle: workStyleField.textField.text ?? "",
+            interest: interestField.textField.text ?? ""
+        )
+        
+        // textField가 다 채워졌는지 확인하기 위해 배열에 저장
+        let isAddInfoEmpty = [
+            userInfo.nickName,
+            userInfo.role,
+            userInfo.techStack,
+            userInfo.tool,
+            userInfo.workStyle,
+            userInfo.interest
+        ]
+        
+        // 텍스트 필드가 전부 채워졌는지 확인하고 서버에 업로드
+        if isAddInfoEmpty.allSatisfy({ !$0.isEmpty }) {
+            UserInfoService.shared.createUserInfo(info: userInfo) { result in
+                switch result {
+                case .success:
+                    let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+                    sceneDelegate?.window?.rootViewController = TabBar() // 메인화면으로 이동
+                    print("회원정보 업로드 성공. | UserDefaults 저장 성공 | MainView로 이동함")
+                case .failure(let error):
+                    print("업로드 실패: \(error)")
                 }
-            } else {
-                basicAlert(title: "오류", message: "빈칸 없이 입력해주세요.")
             }
+        } else {
+            basicAlert(title: "오류", message: "빈칸 없이 입력해주세요.")
         }
     }
     
@@ -297,9 +332,4 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
 
 MARK: - Todo
 
- 글자수 제한
- 한글 영어 구분
- 키보드가 텍스트 필드 가리는 부분 수정
- 공백
- 
 */

--- a/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
+++ b/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
@@ -202,9 +202,9 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
         }
         for checkSpace in techAndStackField { // , 쓰는 필드 | 공백 검사
             let text = checkSpace.text ?? ""
-            // 공백검사
-            if isThereSpaces(text: text) == true {
-                self.basicAlert(title: "오류", message: "공백 및 특수문자는 입력할 수 없습니다.")
+            // 첫글자 공백검사
+            if isFirstCharSpace(text: text) == true {
+                self.basicAlert(title: "오류", message: "첫 글자는 공백으로 작성할 수 없습니다.")
                 return
             }
         }

--- a/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
+++ b/Ting/MyPage/AddUserInfo/AddUserInfoVC.swift
@@ -177,17 +177,17 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
     private func saveBtnTapped() {
         // MARK: - 닉네임 제외 다른 필드 공백, 특수문자 검사
         // 텍스트 필드 배열 생성
-        let otherFields: [UITextField] = [ // , 안쓰는 필드
+        let bothCheck: [UITextField] = [ // 공백, 특수문자 모두 안쓰는 필드
             roleField.textField,
-            workStyleField.textField,
+            workStyleField.textField
+        ]
+        let onlySpaceCheck: [UITextField] = [ // 공백, 특수문자가 필요한 필드
+            techStackField.textField,
+            toolField.textField,
             interestField.textField
         ]
-        let techAndStackField: [UITextField] = [ // , 쓰는 필드
-            techStackField.textField,
-            toolField.textField
-        ]
         // 검사 실행
-        for checkSpaceAndSpecial in otherFields { // , 안쓰는 필드 | 공백, 특수문자 검사
+        for checkSpaceAndSpecial in bothCheck { // 공백, 특수문자 검사
             let text = checkSpaceAndSpecial.text ?? ""
             // 공백검사
             if isThereSpaces(text: text) == true {
@@ -200,7 +200,7 @@ class AddUserInfoVC: UIViewController, UITextFieldDelegate {
                 return
             }
         }
-        for checkSpace in techAndStackField { // , 쓰는 필드 | 공백 검사
+        for checkSpace in onlySpaceCheck { // 첫글자 공백 검사
             let text = checkSpace.text ?? ""
             // 첫글자 공백검사
             if isFirstCharSpace(text: text) == true {

--- a/Ting/MyPage/EditInfo/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfo/EditInfoVC.swift
@@ -204,9 +204,43 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
     // MARK: - Save Button Action
     @objc
     private func saveBtnTapped() {
-        let nickname = nickNameField.textField.text ?? "" // 현재 텍스트필드에 있는 닉네임
+        // MARK: - 닉네임 제외 다른 필드 공백, 특수문자 검사
+        // 텍스트 필드 배열 생성
+        let otherFields: [UITextField] = [ // , 안쓰는 필드
+            roleField.textField,
+            workStyleField.textField,
+            interestField.textField
+        ]
+        let techAndStackField: [UITextField] = [ // , 쓰는 필드
+            techStackField.textField,
+            toolField.textField
+        ]
+        // 검사 실행
+        for checkSpaceAndSpecial in otherFields { // , 안쓰는 필드 | 공백, 특수문자 검사
+            let text = checkSpaceAndSpecial.text ?? ""
+            // 공백검사
+            if isThereSpaces(text: text) == true {
+                self.basicAlert(title: "오류", message: "공백 및 특수문자는 입력할 수 없습니다.")
+                return
+            }
+            // 특수문자 검사
+            if isThereSpecialChar(text: text) == true {
+                self.basicAlert(title: "오류", message: "사용할 수 없는 닉네임입니다.")
+                return
+            }
+        }
+        for checkSpace in techAndStackField { // , 쓰는 필드 | 공백 검사
+            let text = checkSpace.text ?? ""
+            // 공백검사
+            if isThereSpaces(text: text) == true {
+                self.basicAlert(title: "오류", message: "공백 및 특수문자는 입력할 수 없습니다.")
+                return
+            }
+        }
         
         // MARK: 닉네임 중복 검증
+        let nickname = nickNameField.textField.text ?? "" // 현재 텍스트필드에 있는 닉네임
+        
         // 닉네임이 변경되지 않은 경우 바로 저장
         if nickname == originalNickname { // 서버에 있는 닉네임과 대조
             saveUserInfo()

--- a/Ting/MyPage/EditInfo/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfo/EditInfoVC.swift
@@ -232,8 +232,8 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
         for checkSpace in techAndStackField { // , 쓰는 필드 | 공백 검사
             let text = checkSpace.text ?? ""
             // 공백검사
-            if isThereSpaces(text: text) == true {
-                self.basicAlert(title: "오류", message: "공백 및 특수문자는 입력할 수 없습니다.")
+            if isFirstCharSpace(text: text) == true {
+                self.basicAlert(title: "오류", message: "첫 글자는 공백으로 작성할 수 없습니다.")
                 return
             }
         }

--- a/Ting/MyPage/EditInfo/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfo/EditInfoVC.swift
@@ -205,18 +205,19 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
     @objc
     private func saveBtnTapped() {
         // MARK: - 닉네임 제외 다른 필드 공백, 특수문자 검사
+        // MARK: - 닉네임 제외 다른 필드 공백, 특수문자 검사
         // 텍스트 필드 배열 생성
-        let otherFields: [UITextField] = [ // , 안쓰는 필드
+        let bothCheck: [UITextField] = [ // 공백, 특수문자 모두 안쓰는 필드
             roleField.textField,
-            workStyleField.textField,
+            workStyleField.textField
+        ]
+        let onlySpaceCheck: [UITextField] = [ // 공백, 특수문자가 필요한 필드
+            techStackField.textField,
+            toolField.textField,
             interestField.textField
         ]
-        let techAndStackField: [UITextField] = [ // , 쓰는 필드
-            techStackField.textField,
-            toolField.textField
-        ]
         // 검사 실행
-        for checkSpaceAndSpecial in otherFields { // , 안쓰는 필드 | 공백, 특수문자 검사
+        for checkSpaceAndSpecial in bothCheck { // 공백, 특수문자 검사
             let text = checkSpaceAndSpecial.text ?? ""
             // 공백검사
             if isThereSpaces(text: text) == true {
@@ -229,15 +230,14 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
                 return
             }
         }
-        for checkSpace in techAndStackField { // , 쓰는 필드 | 공백 검사
+        for checkSpace in onlySpaceCheck { // 첫글자 공백 검사
             let text = checkSpace.text ?? ""
-            // 공백검사
+            // 첫글자 공백검사
             if isFirstCharSpace(text: text) == true {
                 self.basicAlert(title: "오류", message: "첫 글자는 공백으로 작성할 수 없습니다.")
                 return
             }
         }
-        
         // MARK: 닉네임 중복 검증
         let nickname = nickNameField.textField.text ?? "" // 현재 텍스트필드에 있는 닉네임
         

--- a/Ting/MyPage/MyPageMain/MyPageMainVC.swift
+++ b/Ting/MyPage/MyPageMain/MyPageMainVC.swift
@@ -232,7 +232,7 @@ class MyPageMainVC: UIViewController {
             case .success(let userInfo):
                 DispatchQueue.main.async {
                     self.updateLabels(with: userInfo)
-                    self.updateCustomViews(with: userInfo)
+                    self.updateTextFields(with: userInfo)
                 }
             case .failure(let error):
                 print("데이터 가져오기 실패: \(error.localizedDescription)")
@@ -245,11 +245,32 @@ class MyPageMainVC: UIViewController {
         role.text = userInfo.role
     }
     // textFieldCard 항목들에 추가
-    private func updateCustomViews(with userInfo: UserInfo) {
-        techStackField.updateDetailText(userInfo.techStack)
-        toolField.updateDetailText(userInfo.tool)
+    private func updateTextFields(with userInfo: UserInfo) {
+        // 특수문자 허용된 두 필드만 따로 저장
+        let formattedTechStack = formatString(userInfo.techStack)
+        let formattedTool = formatString(userInfo.tool)
+        
+        // 변환된 값을 textFieldCard에 업데이트
+        techStackField.updateDetailText(formattedTechStack)
+        toolField.updateDetailText(formattedTool)
         workStyleField.updateDetailText(userInfo.workStyle)
         interestField.updateDetailText(userInfo.interest)
+    }
+
+    // 마이페이지에서 출력될 때 ,뒤에 공백을 추가
+    private func formatString(_ input: String) -> String {
+        // ,로 구분된 문자열을 분리
+        let components = input.split(separator: ",")
+        
+        // 마지막 항목을 제외한 항목들에 콤마와 공백을 추가
+        let formattedString = components.dropLast().map { "\($0), " }.joined()
+        
+        // 마지막 항목은 그대로 추가
+        if let lastComponent = components.last {
+            return formattedString + lastComponent
+        }
+        
+        return formattedString
     }
     
     // MARK: - 로그아웃 로직

--- a/Ting/MyPage/MyPageMain/MyPageMainVC.swift
+++ b/Ting/MyPage/MyPageMain/MyPageMainVC.swift
@@ -246,31 +246,10 @@ class MyPageMainVC: UIViewController {
     }
     // textFieldCard 항목들에 추가
     private func updateTextFields(with userInfo: UserInfo) {
-        // 특수문자 허용된 두 필드만 따로 저장
-        let formattedTechStack = formatString(userInfo.techStack)
-        let formattedTool = formatString(userInfo.tool)
-        
-        // 변환된 값을 textFieldCard에 업데이트
-        techStackField.updateDetailText(formattedTechStack)
-        toolField.updateDetailText(formattedTool)
+        techStackField.updateDetailText(userInfo.techStack)
+        toolField.updateDetailText(userInfo.tool)
         workStyleField.updateDetailText(userInfo.workStyle)
         interestField.updateDetailText(userInfo.interest)
-    }
-
-    // 마이페이지에서 출력될 때 ,뒤에 공백을 추가
-    private func formatString(_ input: String) -> String {
-        // ,로 구분된 문자열을 분리
-        let components = input.split(separator: ",")
-        
-        // 마지막 항목을 제외한 항목들에 콤마와 공백을 추가
-        let formattedString = components.dropLast().map { "\($0), " }.joined()
-        
-        // 마지막 항목은 그대로 추가
-        if let lastComponent = components.last {
-            return formattedString + lastComponent
-        }
-        
-        return formattedString
     }
     
     // MARK: - 로그아웃 로직


### PR DESCRIPTION
## 주요내용
- 기존 로직을 사용해서 닉네임 이외의 택스트필드들도 공백, 특수문자 검증을 구현하였습니다.
- 기술 스택, 사용 툴, 관심사 같은 필드는 공백 및 특수문자가 필요하므로, 
첫 글자를 공백으로 작성하여 빈 값을 만드는 것을 방지하기 위해
첫글자가 공백인지 아닌지만 검사하도록 로직을 새로 구현하고 적용시켰습니다.  
- 협업 방식과 직군 필드는 공백과 특수문자가 필요없으므로 공백, 특수문자 모두 적용시켰습니다.



Resolves: #245 