### PR TITLE
Fix: 로그아웃, 종료 후 약관 동의 데이터 사라지는 버그 수정

### DIFF
--- a/Ting/Main/MainView/MainViewCell.swift
+++ b/Ting/Main/MainView/MainViewCell.swift
@@ -87,12 +87,12 @@ class MainViewCell: UICollectionViewCell {
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(tagStackView.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview().inset(10)
-            $0.height.equalTo(20)
+            $0.height.equalTo(26)
         }
         
         cardView.addSubview(detailLabel)
         detailLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(4)
+            $0.top.equalTo(titleLabel.snp.bottom)
             $0.leading.trailing.equalToSuperview().inset(10)
             $0.bottom.equalToSuperview().inset(26)
         }

--- a/Ting/SignUp/SignUpView/SignUpVC.swift
+++ b/Ting/SignUp/SignUpView/SignUpVC.swift
@@ -86,7 +86,7 @@ extension SignUpVC: ASAuthorizationControllerDelegate {
             "createdAt": Timestamp()      // 생성 날짜
         ]
         
-        db.collection("users").document(user.uid).setData(userData) { error in
+        db.collection("users").document(user.uid).setData(userData, merge: true) { error in
             if let error = error {
                 print("Firestore에 사용자 데이터 저장 실패: \(error.localizedDescription)")
             } else {


### PR DESCRIPTION
## 변경사항
- merge: true 코드 추가
- 영진님 메인뷰 셀 UI 수정

## 주요내용
- "merge: true" 사용으로 Firestore에서 기존 필드는 유지하면서 새로운 데이터만 추가
- UI 수정

## 스크린샷
.

## 추가계획, 고민
- 버그 확인 및 수정
- 
- 

Resolves: #251