### PR TITLE
Fix: 신고 발생시 슬랙 알림이 오는 기능 관련 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,11 @@
 .AppleDouble
 .LSOverride
 
-**/Debug.xcconfig
-**/Release.xcconfig
 
 # Icon must end with two \r
 Icon
 
+SlackWebhookURL.swift
 
 # Thumbnails
 ._*

--- a/Ting.xcodeproj/project.pbxproj
+++ b/Ting.xcodeproj/project.pbxproj
@@ -180,7 +180,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 76CW3C5UU7;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -222,7 +222,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 76CW3C5UU7;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Ting/API/SlackService.swift
+++ b/Ting/API/SlackService.swift
@@ -13,11 +13,8 @@ class SlackService {
     
     // 생성자: Webhook URL을 설정
     init() {
-        // MARK: - Slack에서 받은 Webhook URL | 절대 틀리면 안됨.
-        let urlString = "https://hooks.slack.com/services/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"
-        
         // URL 문자열을 URL 객체로 변환, 실패할 경우 fatalError로 앱이 종료되도록 처리
-        guard let url = URL(string: urlString) else {
+        guard let url = URL(string: SlackWebhookURL.key) else {
             fatalError("잘못된 Webhook URL입니다.")
         }
         

--- a/Ting/MyPage/EditInfo/EditInfoVC.swift
+++ b/Ting/MyPage/EditInfo/EditInfoVC.swift
@@ -206,7 +206,7 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
     private func saveBtnTapped() {
         // MARK: - 닉네임 제외 다른 필드 공백, 특수문자 검사
         // 텍스트 필드 배열 생성
-        let bothCheck: [UITextField] = [
+        let textFieldList: [UITextField] = [
             roleField.textField,
             techStackField.textField,
             toolField.textField,
@@ -214,7 +214,7 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
             interestField.textField
         ]
         // 첫글자 공백 검사
-        for checkSpace in bothCheck {
+        for checkSpace in textFieldList {
             let text = checkSpace.text ?? ""
             // 첫글자 공백검사
             if isFirstCharSpace(text: text) == true {
@@ -311,7 +311,8 @@ class EditInfoVC: UIViewController, UITextFieldDelegate {
         tapGesture.cancelsTouchesInView = false // 다른 터치 이벤트도 전달되도록 설정
         view.addGestureRecognizer(tapGesture)
     }
-    @objc private func keyboardDownAction() {
+    @objc
+    private func keyboardDownAction() {
         view.endEditing(true)
     }
     


### PR DESCRIPTION
## 수정 사항

### 원인
- 기존 Slack Webhook URL이 깃허브에 같이 올라가면서, 오픈되어서 Slack측에서 자동으로 밴을 시키는 현상 발생
결과 -> 코드와 로직은 있지만 WebhookURL 값이 없기 때문에 작동하지 않음.

### 해결
- Webhook URL을 별도의 파일로 분리하고, 이그노어에 추가하는 등, 추적되지 않도록 수정

### 결과
- 게시글 신고시 개발팀 슬랙으로 정상적으로 봇이 메시지를 전송함.

<img width="576" alt="스크린샷 2025-02-25 오후 5 09 07" src="https://github.com/user-attachments/assets/42b097a7-440b-4ab6-8b50-b34fb487f75f" />  
  
-----------

Resolves: #260